### PR TITLE
Set enable-recursive-minibuffers locally

### DIFF
--- a/embark.el
+++ b/embark.el
@@ -243,7 +243,6 @@ Meant to be added to `completion-setup-hook'."
 (defvar embark--target nil "String the next action will operate on.")
 (defvar embark--keymap nil "Keymap to activate for next action.")
 
-(defvar embark--old-erm nil "Stores value of `enable-recursive-minibuffers'.")
 (defvar embark--overlay nil
   "Overlay to communicate embarking on an action to the user.")
 
@@ -306,7 +305,6 @@ return nil."
 (defun embark--cleanup ()
   "Remove all hooks and modifications."
   (unless embark--target
-    (setq enable-recursive-minibuffers embark--old-erm)
     (remove-hook 'minibuffer-setup-hook #'embark--inject)
     (remove-hook 'post-command-hook #'embark--cleanup)
     (when embark--overlay
@@ -418,8 +416,7 @@ argument), exit all minibuffers too."
   (interactive "P")
   (embark--setup)
   (unless exitp
-    (setq embark--old-erm enable-recursive-minibuffers
-          enable-recursive-minibuffers t))
+    (setq-local enable-recursive-minibuffers t))
   (embark--show-indicator)
   (embark--bind-actions exitp))
 


### PR DESCRIPTION
When using `embark-exit-and-act` the initial value of `enable-recursive-minibuffers` is not stored. Because `embark--old-erm` is `nil`,  `enable-recursive-minibuffers` will be set to `nil` on clean up even if it was `t` before.

Setting `embark--old-erm` could be moved outside the `unless exitp` clause to fix this but I have proposed another approach which is to set `enable-recursive-minibuffers` locally so the initial value doesn't have to be stored and the setting only affects the current minibuffer session.