### PR TITLE
Fix replace behaviour of embark-shell-command-on-buffer

### DIFF
--- a/embark.el
+++ b/embark.el
@@ -590,14 +590,17 @@ The insert path is relative to the previously selected buffer's
 (defun embark-shell-command-on-buffer (buffer command &optional replace)
   "Run shell COMMAND on contents of BUFFER.
 Called with \\[universal-argument], replace contents of buffer
-with command output."
+with command output. For replacement behaviour see
+`shell-command-dont-erase-buffer' setting."
   (interactive
    (list
     (read-buffer "Buffer: ")
     (read-shell-command "Shell command: ")
     current-prefix-arg))
   (with-current-buffer buffer
-    (shell-command-on-region (point-min) (point-max) command replace)))
+    (shell-command-on-region (point-min) (point-max)
+                             command
+                             (and replace (current-buffer)))))
 
 (defun embark-bury-buffer ()
   "Bury embark target buffer."


### PR DESCRIPTION
`shell-command-on-region` needs to get passed the output buffer to replace the contents, otherwise it only inserts the output. I also mention `shell-command-dont-erase-buffer` in the docstring which can be used to adjust the behaviour.