### PR TITLE
Get button label with possible properties

### DIFF
--- a/embark.el
+++ b/embark.el
@@ -412,7 +412,9 @@ return nil."
 (defun embark-button-label ()
   "Return the label of the button at point."
   (when-let* ((button (button-at (point)))
-              (label (button-label button)))
+              (label (buffer-substring
+                      (button-start button)
+                      (buffer-end button))))
     (if (eq embark--type 'file)
         (abbreviate-file-name (expand-file-name label))
       label)))


### PR DESCRIPTION
This preserves text properties that are possibly attached to the candidates (I have tested this with a custom grep command which doesn't work without this because it gets the target info from the properties of the search results). 