### PR TITLE
Propose changes for target based classification

### DIFF
--- a/embark.el
+++ b/embark.el
@@ -385,7 +385,7 @@ Always keep the non-local value equal to nil.")
            'file))))
 
 (defun embark-classify ()
-  "Classify current minibuffer completion session."
+  "Classify current context."
   (or (embark-cached-type)
       (run-hook-with-args-until-success 'embark-classifiers)
       (embark-target-type)

--- a/embark.el
+++ b/embark.el
@@ -110,14 +110,12 @@
   :group 'embark)
 
 (defcustom embark-classifiers
-  '(embark-cached-type
-    embark-category-type
+  '(embark-category-type
     embark-package-type
     embark-symbol-completion-type
     embark-dired-type
-    embark-ibuffer-type
-    embark-target-type)
-  "List of functions to classify according to current context.
+    embark-ibuffer-type)
+  "List of functions to classify according to current buffer context.
 Each function should take no arguments and return the type
 symbol, or nil to indicate it could not determine the type in
 current context."
@@ -388,7 +386,9 @@ Always keep the non-local value equal to nil.")
 
 (defun embark-classify ()
   "Classify current minibuffer completion session."
-  (or (run-hook-with-args-until-success 'embark-classifiers)
+  (or (embark-cached-type)
+      (run-hook-with-args-until-success 'embark-classifiers)
+      (embark-target-type)
       'general))
 
 (defun embark-target ()

--- a/embark.el
+++ b/embark.el
@@ -399,8 +399,12 @@ Always keep the non-local value equal to nil.")
 
 (defun embark-symbol-target-type (cand)
   "Report symbol type if CAND is a known symbol."
-  (when (intern-soft cand)
-    'symbol))
+  (let ((sym (intern-soft cand)))
+    (when (and sym
+               (or (boundp sym)
+                   (functionp sym)
+                   (facep sym)))
+    'symbol)))
 
 (defun embark-buffer-target-type (cand)
   "Remport buffer type if CAND is a buffer name."

--- a/embark.el
+++ b/embark.el
@@ -145,7 +145,8 @@ fallback to the `general' type."
     embark-symbol-at-point)
   "List of functions to determine the target in current context.
 Each function should take no arguments and return either a target
-string or nil (to indicate it found no target)."
+string or nil (to indicate it found no target). If the region is
+active the region content is used as current target."
   :type 'hook
   :group 'embark)
 
@@ -392,6 +393,15 @@ Always keep the non-local value equal to nil.")
               (run-hook-with-args-until-success 'embark-target-finders)))
     (run-hook-with-args-until-success 'embark-target-classifiers target)))
 
+(defun embark-active-region-type ()
+  "Report type of active region target."
+  (when-let ((target
+              (and (region-active-p)
+                   (buffer-substring (region-beginning)
+                                     (region-end)))))
+    (or (run-hook-with-args-until-success 'embark-target-classifiers target)
+        'general)))
+
 (defun embark-file-target-type (cand)
   "Report file type if CAND is a file."
   (when (file-exists-p cand)
@@ -413,7 +423,8 @@ Always keep the non-local value equal to nil.")
 
 (defun embark-classify ()
   "Classify current context."
-  (or (embark-cached-type)
+  (or (embark-active-region-type)
+      (embark-cached-type)
       (run-hook-with-args-until-success 'embark-classifiers)
       (embark-target-type)
       'general))


### PR DESCRIPTION
I have many completion commands which don't report the completion category and there might be other contexts where it is more useful to classify based on target. I noticed that we could distinguish between classification of buffer context and classification based on target. This also removes the doubling of ffap and symbol at point in classifiers and target finders. If the buffer context doesn't report a type we can fallback to determine the type using the current target.

I also made the functions in `embark-classifiers` position independent by moving `embark-cached-type` and `embark-target-type` into `embark-classify`. The reasoning is that the cached type is meant for internal use and should always be checked first and the target based classification should always be last. This makes user configuration easier because one has not to keep the order of those in mind.

Here are a two addition thoughts about classification that I think are worth noting: 

- There could be custom completion sessions which list targets with multiple types (for example my custom switch buffer command contains buffers and recent files). This makes occur problematic for those completion sessions. One possible solution I see would be to pick only those candidates which report the same target type if the class for occur  was determined by target classification. 

- In theory a target could have multiple types (the name could be buffer/file/symbol at the same time but those situations should be rare and we can probably ignore that for now). In the future we could maybe allow classifiers to report multiple types and then decide how to handle this generally if we think it's worth the effort. 

