### PR TITLE
Some fixes for embark-occur

### DIFF
--- a/embark.el
+++ b/embark.el
@@ -825,7 +825,8 @@ To be used as an annotation function for symbols in `embark-occur'."
 
 (defun embark-annotation-function-metadatum (cand)
   "Use the `annotation-function' metadatum to annotate CAND."
-  (when-let ((annot-fn (or (completion-metadata-get (embark--metadata)
+  (when-let ((annot-fn (or embark-occur-annotation-func
+                           (completion-metadata-get (embark--metadata)
                                                     'annotation-function)
                            (plist-get completion-extra-properties
                                       :annotation-function)))
@@ -991,6 +992,9 @@ If you are using `embark-completing-read' as your
 (defvar-local embark-occur-linked-buffer nil
   "Buffer local variable indicating which Embark Buffer to update.")
 
+(defvar-local embark-occur-annotation-func nil
+  "Annotation function of minibuffer session for this occur.")
+
 (defvar-local embark--live-occur--timer nil
   "Timer scheduled to update Embark Live Occur buffer.")
 
@@ -1119,6 +1123,11 @@ Argument BUFFER-NAME specifies the name of the created buffer."
                                              ; buffer is displayed, so
                                              ; they can use the window
       (setq embark-occur-from from)
+      (setq embark-occur-annotation-func
+            (or (completion-metadata-get (embark--metadata)
+                                         'annotation-function)
+                (plist-get completion-extra-properties
+                           :annotation-function)))
       (add-hook 'tabulated-list-revert-hook #'embark-occur--revert)
       (setq embark-occur-view
             (or initial-view

--- a/embark.el
+++ b/embark.el
@@ -1128,7 +1128,7 @@ Argument BUFFER-NAME specifies the name of the created buffer."
                                          'annotation-function)
                 (plist-get completion-extra-properties
                            :annotation-function)))
-      (add-hook 'tabulated-list-revert-hook #'embark-occur--revert)
+      (add-hook 'tabulated-list-revert-hook #'embark-occur--revert  nil t)
       (setq embark-occur-view
             (or initial-view
                 (alist-get embark--type embark-occur-initial-view-alist)

--- a/embark.el
+++ b/embark.el
@@ -1148,7 +1148,8 @@ window placement."
   (let ((occur-window (display-buffer occur-buffer action)))
     (with-selected-window occur-window
       (run-mode-hooks)
-      (revert-buffer))
+      (revert-buffer)
+      (tabulated-list-init-header))
     occur-window))
 
 (defun embark-occur--initial-view-arg ()


### PR DESCRIPTION
This PR addresses the following points:

- Because `embark-occur` runs after exit the metadata can't be retrieved any more when the buffer gets reverted. I added a buffer local variable `embark-occur-annotation-func` to remember the annotation function for the current occur buffer.
- Avoid adjusting `tabulated-list-revert-hook` globally by adding `embark-occur--revert` locally
- I noticed that embark occur buffers don't show the header line even if `tabulated-list-use-header-line` is non nil so I added a call to `tabulated-list-init-header` on display of the embark occur buffer (this is mentioned in the docstring of `tabulated-list-mode` for modes which derive from it). One can use `embark-occur-mode-hook` to change the setting for `tabulated-list-use-header-line`