### PR TITLE
Fix error when getting docs of alias for a not yet defined function

### DIFF
--- a/embark.el
+++ b/embark.el
@@ -828,7 +828,11 @@ To be used as an annotation function for symbols in `embark-occur'."
   (when-let* ((symbol (intern name))
               (docstring
                (if (fboundp symbol)
-                   (documentation symbol)
+                   ;; As per `describe-function-1' `documentation' might throw
+                   ;; an error for alias of a not yet defined function.
+                   (condition-case nil
+                       (documentation symbol)
+                     ((invalid-function void-function) nil))
                  (or
                   (documentation-property symbol 'variable-documentation)
                   (documentation-property symbol 'face-documentation)


### PR DESCRIPTION
I got an invalid-function error when invoking `embark-occur` and fixed it according to the comments in `describe-function-1`: 

```elisp
...
(condition-case nil
    ;; FIXME: Maybe `documentation' should return nil
    ;; for invalid functions i.s.o. signaling an error.
    (documentation function t)
  ;; E.g. an alias for a not yet defined function.
  ((invalid-function void-function) nil))
...
```