### PR TITLE
generalize embark-save

### DIFF
--- a/embark.el
+++ b/embark.el
@@ -1422,10 +1422,10 @@ This is whatever command opened the minibuffer in the first place."
   (with-current-buffer embark--target-buffer
     (insert (substring-no-properties (embark-target)))))
 
-(defun embark-save ()
-  "Save embark target in the kill ring."
-  (interactive)
-  (kill-new (substring-no-properties (embark-target))))
+(defun embark-save (str)
+  "Save STR in the kill ring."
+  (interactive "sStr: ")
+  (kill-new str))
 
 (defun embark-eshell-in-directory ()
   "Run eshell in directory of embark target."


### PR DESCRIPTION
This one is weird, I tried to generalize/simplify embark-save too and suddenly embark behaves incorrectly on Selectrum. After executing the command with embark-act-noexit, the saved candidate is somehow entered and the candidate lists only shows this one candidate instead of the full candidate list which has been there before. But it does not happen on icomplete.