### PR TITLE
remove embark-undefined

### DIFF
--- a/embark.el
+++ b/embark.el
@@ -680,6 +680,8 @@ BODY."
        (top-level))))
 
 (defun embark--setup-action (continuep)
+  "Setup Embark action when exiting the transient keymap.
+If CONTINUEP is nil exit all minibuffers."
   (run-hooks 'embark-pre-action-hook)
   (setq embark--action this-command)
   ;; Only set prefix if it was given, prefix can still be added after calling
@@ -1462,7 +1464,7 @@ This is whatever command opened the minibuffer in the first place."
     (message "No homepage found for `%s'" pkg)))
 
 (defun embark-insert-relative-path (file)
-  "Insert relative path to embark target.
+  "Insert relative path to FILE.
 The insert path is relative to `default-directory'."
   (interactive "FFile: ")
   (insert (file-relative-name (substitute-in-file-name file))))


### PR DESCRIPTION
* Check if key is present in embark--keymap.
* Print error message if key is not present.
* The behavior is more strict than before, every keypress must be handled properly by embark
* Do you want to exit the transient map or not if an non-action key is pressed?
  In contrast to the current behavior, the transient map does not exit anymore.
  I prefer that in comparison to the current behavior for non-action keys.
  You can always quit explicitly via C-g.
* Minor doc fixes via package-lint