### PR TITLE
Fix package name to conform with libary header conventions

### DIFF
--- a/embark.el
+++ b/embark.el
@@ -1,4 +1,4 @@
-;;; Embark.el --- Conveniently act on minibuffer completions   -*- lexical-binding: t; -*-
+;;; embark.el --- Conveniently act on minibuffer completions   -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2020  Omar Antolín Camarena
 


### PR DESCRIPTION
Small fix that I noticed when trying to install Embark using Nix as it was being installed as `Embark` (capitalized). This was causing it not be able to be loaded properly due to case sensitivity. The official library header conventions state that this should be the base name of the file, so I have corrected it.