### PR TITLE
Fix recursive use of embark-act, third solution

### DIFF
--- a/embark.el
+++ b/embark.el
@@ -786,9 +786,11 @@ minibuffer, and if you use \\[universal-argument] it will do the opposite."
                                                target)))
     (if (null action)
         (minibuffer-message "Canceled")
-      (embark--act action target)
-      (when (if embark-quit-after-action (not arg) arg)
-        (embark-quit)))))
+      (unwind-protect
+          (embark--act action target)
+        (and (if embark-quit-after-action (not arg) arg)
+             (minibufferp)
+             (embark-quit))))))
 
 (defun embark--become-keymap ()
   "Return keymap of commands to become for current command."


### PR DESCRIPTION
Fixes #121.
Sorry to bombard you with possible solutions, they just keep coming to my head.
This one you will probably like the most for its simplicity. In essence it is
similar to #127 in that it uses `run-at-time` but it makes use of the existing
one inside `embark-quit` rather than introducing a new one.

The only downside is that quitting normally with C-g instead of with an inner
embark-act will now also quit the outer minibuffer.
