### PR TITLE
Fix recursive use of embark-act

### DIFF
--- a/embark.el
+++ b/embark.el
@@ -785,9 +785,11 @@ minibuffer, and if you use \\[universal-argument] it will do the opposite."
                                                target)))
     (if (null action)
         (minibuffer-message "Canceled")
-      (embark--act action target)
-      (when (if embark-quit-after-action (not arg) arg)
-        (embark-quit)))))
+      (unwind-protect
+          (embark--act action target)
+        (and (if embark-quit-after-action (not arg) arg)
+             (minibufferp)
+             (embark-quit))))))
 
 (defun embark--become-keymap ()
   "Return keymap of commands to become for current command."

--- a/embark.el
+++ b/embark.el
@@ -664,18 +664,21 @@ Collect buffers."
                (overlay-get minibuffer-message-overlay 'after-string))))
         (when (and msg (string-match-p "\\` *\\[.+\\]\\'" msg))
           (setq msg (substring (string-trim msg) 1 -1)))
-        (run-at-time
-         0 nil
-         (lambda ()
-           (let* ((new-miniwin (active-minibuffer-window))
-                  (minibuf (when new-miniwin (window-buffer new-miniwin))))
-             (set-window-configuration wincfg)
-             (if new-miniwin
-                 (set-window-buffer miniwin minibuf)
-               (when (minibufferp)
-                 (select-window (get-mru-window)))))
-           (message msg)))
-        (abort-recursive-edit)))))
+        (let ((hook))
+          (setq
+           hook
+           (lambda ()
+             (remove-hook 'post-command-hook hook)
+             (let* ((new-miniwin (active-minibuffer-window))
+                    (minibuf (when new-miniwin (window-buffer new-miniwin))))
+               (set-window-configuration wincfg)
+               (if new-miniwin
+                   (set-window-buffer miniwin minibuf)
+                 (when (minibufferp)
+                   (select-window (get-mru-window)))))
+             (message msg)))
+          (add-hook 'post-command-hook hook))))
+    (abort-recursive-edit)))
 
 (defun embark--act (action target)
   "Perform ACTION injecting the TARGET."


### PR DESCRIPTION
Fixes  #121.
Closed all other pull request as they are pretty much an embarrassment compared
to this one.
It simply replaces `run-at-time` with an ephemeral `post-command-hook`. Perhaps
it would be worth to think about all the other uses of `run-at-time` with an
ephemeral post-command-hook. I'm personally not really a fan run-at-time
because it breaks keyboard macros. I know that embark is currently not usable
for kmacros because quitting aborts a macro definition but perhaps we should
make it ready for a future emacs releases where quitting might not abort a
macro definition any more.
