### PR TITLE
Fix embark-goto-location with previous next-error

### DIFF
--- a/embark.el
+++ b/embark.el
@@ -1895,7 +1895,9 @@ Return the category metadatum as the type of the target."
       (insert location "\n")
       (grep-mode)
       (goto-char (point-min))
-      (let ((inhibit-message t))
+      (let ((inhibit-message t)
+            (next-error-find-buffer-function
+             (lambda (&rest _args) (current-buffer))))
         (next-error 0 t)))))
 
 (defalias 'embark-execute-command


### PR DESCRIPTION
In cases where `next-error` was used in another buffer prior to doing an
`embark-collect-snapshopt`, that buffer will be preferred when doing
`next-error`. By setting the `next-error-find-buffer-function`, we override that
behavior

Fixes the issue I mentioned here: https://github.com/oantolin/embark/issues/146#issuecomment-779989307

Another approach is to set `next-error-last-buffer`, but this is more direct and `next-error-find-buffer-function` has higher precedence.