### PR TITLE
embark-find-definition: push markers

### DIFF
--- a/embark.el
+++ b/embark.el
@@ -1921,6 +1921,7 @@ When called with a prefix argument, open dired in another window."
 (defun embark-find-definition (symbol)
   "Find definition of SYMBOL."
   (interactive "SSymbol: ")
+  (xref-push-marker-stack)
   (cond
    ((fboundp symbol) (find-function symbol))
    ((boundp symbol) (find-variable symbol))))


### PR DESCRIPTION
This pushes an appropriate entry onto the xref marker stack, allowing `pop-tag-mark` to work.

`xref--push-markers` additionally pushes something onto the mark ring, though I'm not sure what the effect is supposed to be; `M-x pop-global-mark` works either way:

https://github.com/emacs-straight/xref/blob/a3b455273d751dbe80abc8f0e9bb5a8c78abb746/xref.el#L1148-L1151