### PR TITLE
Prompter config and BUG

### DIFF
--- a/README.org
+++ b/README.org
@@ -241,8 +241,23 @@ reasonable starting configuration:
 
   (use-package embark
     :ensure t
+
     :bind
-    ("C-S-a" . embark-act))              ; pick some comfortable binding
+    (("C-S-a" . embark-act)       ;; pick some comfortable binding
+     ("C-h B" . embark-bindings)) ;; alternative for `describe-bindings'
+
+    :init
+
+    ;; Optionally replace the key help with a completing-read interface
+    (setq prefix-help-command #'embark-prefix-help-command)
+
+    :config
+
+    ;; Hide the mode line of the Embark live/completions buffers
+    (add-to-list 'display-buffer-alist
+                 '("\\`\\*Embark Collect \\(Live\\|Completions\\)\\*"
+                   nil
+                   (window-parameters (mode-line-format . none)))))
 
   ;; Consult users will also want the embark-consult package.
   (use-package embark-consult


### PR DESCRIPTION
I would like to have the @ configurable via a defcustom. 

Unfortunately I just found that out that the @ prompter is broken since we switched to the formatted candidates. :cry: It also cannot not work with narrowing since we have the disambiguation problem again. it seems the prompter protocol must be changed such that the prompter returns a `(cons key cmd)` instead of only the `cmd`? I haven't done that yet here. How would you like to repair this?