### PR TITLE
Add "ext:" to declare-function invocations for external fns

### DIFF
--- a/embark-consult.el
+++ b/embark-consult.el
@@ -194,7 +194,7 @@ The elements of LINES are assumed to be values of category `consult-line'."
 ;;; Support for consult-grep
 
 (defvar wgrep-header/footer-parser)
-(declare-function wgrep-setup "wgrep")
+(declare-function wgrep-setup "ext:wgrep")
 
 (defun embark-consult-export-grep (lines)
   "Create a grep mode buffer listing LINES."

--- a/embark.el
+++ b/embark.el
@@ -1902,9 +1902,9 @@ buffer for each type of completion."
 
 ;; selectrum
 
-(declare-function selectrum--get-meta "selectrum")
-(declare-function selectrum-get-current-candidate "selectrum")
-(declare-function selectrum-get-current-candidates "selectrum")
+(declare-function selectrum--get-meta "ext:selectrum")
+(declare-function selectrum-get-current-candidate "ext:selectrum")
+(declare-function selectrum-get-current-candidates "ext:selectrum")
 
 (defun embark-target-selectrum-selection ()
   "Target the currently selected item in Selectrum.
@@ -1928,8 +1928,8 @@ Return the category metadatum as the type of the candidates."
 
 ;; ivy
 
-(declare-function ivy--expand-file-name "ivy")
-(declare-function ivy-state-current "ivy")
+(declare-function ivy--expand-file-name "ext:ivy")
+(declare-function ivy-state-current "ext:ivy")
 (defvar ivy-text)
 (defvar ivy-last)
 (defvar ivy--old-cands) ; this stores the current candidates :)


### PR DESCRIPTION
Per the Help page for declare-function, "A FILE with an 'ext:' prefix is an external file.
check-declare will check such files if they are found, and skip
them without error if they are not."