### PR TITLE
Implement affixation-function support

### DIFF
--- a/embark.el
+++ b/embark.el
@@ -1463,7 +1463,7 @@ key binding for it.  Or alternatively you might want to enable
                                      0 length 'face nil suffix)))
                        (when facesp (add-face-text-property
                                      0 length 'default t suffix))
-                       `(,cand [(,(if prefix (concat prefix cand) cand) type embark-collect-entry)
+                       `(,cand [(,(if prefix (propertize cand 'line-prefix prefix) cand) type embark-collect-entry)
                                 (,suffix
                                  ,@(unless facesp
                                      '(face embark-collect-annotation)))])))


### PR DESCRIPTION
I implemented affixation-function support. But I wonder if somehow the export could be improved such that the annotations are actually applied during export/snapshot. This would make fewer problems and you would also get annotations if the minibuffer is closed (See separate issue #203).