### PR TITLE
Don't let-bind prefix-arg

### DIFF
--- a/embark.el
+++ b/embark.el
@@ -846,10 +846,10 @@ minibuffer before executing the action."
                             (let ((enable-recursive-minibuffers t)
                                   (embark--command command)
                                   (this-command action)
-                                  (prefix-arg prefix)
                                   ;; the next two avoid mouse dialogs
                                   (use-dialog-box nil)
                                   (last-nonmenu-event 13))
+                              (setq prefix-arg prefix)
                               (command-execute action))
                             (setq final-window (selected-window))
                             (run-hooks 'embark-post-action-hook))


### PR DESCRIPTION
This fixes the following problem:
Press `C-u C-.` for non-quitting embark-act and then press `C-u i` to insert
the target.
(`C-u` has no effect on insertion in this case. It could have, if embark-insert
supported a prefix argument, but this isn't important for this issue.)
Now press `SPC`. 4 spaces will be inserted because the prefix-arg wasn't
cleared.
