### PR TITLE
Deprecate embark-consult-preview in favor of consult-preview-at-point

### DIFF
--- a/README.org
+++ b/README.org
@@ -215,7 +215,7 @@ reasonable starting configuration:
     ;; if you want to have consult previews as you move around an
     ;; auto-updating embark collect buffer
     :hook
-    (embark-collect-mode . embark-consult-preview-minor-mode))
+    (embark-collect-mode . consult-preview-at-point-mode))
 #+end_src
 
 Other Embark commands such as =embark-become=, =embark-collect-snapshot=,

--- a/embark.texi
+++ b/embark.texi
@@ -14,7 +14,6 @@
 @finalout
 @titlepage
 @title Embark: Emacs Mini-Buffer Actions Rooted in Keymaps
-@author Omar Antolín Camarena
 @end titlepage
 
 @contents
@@ -27,7 +26,7 @@
 @menu
 * Overview::
 * Configuration::
-* Embark, Marginalia and Consult: Embark Marginalia and Consult. 
+* Embark, Marginalia and Consult: Embark Marginalia and Consult.
 
 @detailmenu
 --- The Detailed Node Listing ---
@@ -174,7 +173,7 @@ additional annotations.
 
 @item
 The @samp{embark-collect-live} variant of @samp{embark-collect-snapshot} produces
-``live'' Embark Collect buffers, meaning they auto-update as the set
+"live" Embark Collect buffers, meaning they auto-update as the set
 of candidates changes. Most users of visual completion UIs such as
 Vertico, Icomplete, Selectrum or Ivy will probably either not want
 to use this, to avoid seeing double, or to configure their
@@ -201,7 +200,7 @@ use the grepping commands from the @uref{https://github.com/minad/consult/, Cons
 @samp{consult-git-grep} or @samp{consult-ripgrep}.
 @end itemize
 
-These are always available as ``actions'' (although they do not act on
+These are always available as "actions" (although they do not act on
 just the current target but on all candidates) for @samp{embark-act} and are
 bound to @samp{S}, @samp{L} and @samp{E}, respectively, in @samp{embark-general-map}. This means
 that you do not have to bind your own key bindings for these
@@ -301,7 +300,7 @@ reasonable starting configuration:
   ;; if you want to have consult previews as you move around an
   ;; auto-updating embark collect buffer
   :hook
-  (embark-collect-mode . embark-consult-preview-minor-mode))
+  (embark-collect-mode . consult-preview-at-point-mode))
 @end lisp
 
 Other Embark commands such as @samp{embark-become}, @samp{embark-collect-snapshot},
@@ -363,7 +362,7 @@ Note that both the variable @samp{embark-quit-after-action} and @samp{C-u} have 
 effect when you call @samp{embark-act} outside the minibuffer.
 
 Having @samp{embark-act} @emph{not} quit the minibuffer can be useful to turn
-commands into little ``thing managers''. For example, you can use
+commands into little "thing managers". For example, you can use
 @samp{find-file} as a little file manager or @samp{describe-package} as a little
 package manager: you can run those commands, perform a series of
 actions, and then quit the command.
@@ -386,11 +385,11 @@ behavior of @samp{embark-act} and define a non-quitting version as follows:
 @section Allowing the target to be edited before acting on it
 
 By default, for most commands @samp{embark} inserts the target of the action
-into the next minibuffer prompt and ``presses @samp{RET}'' for you, accepting
+into the next minibuffer prompt and "presses @samp{RET}" for you, accepting
 the target as is.
 
 For some commands this might be undesirable, either for safety
-(because a command is ``hard to undo'', like @samp{delete-file} or
+(because a command is "hard to undo", like @samp{delete-file} or
 @samp{kill-buffer}), or because further input is required next to the target
 (like when using @samp{shell-command}: the target is the file and you still
 need to enter a shell command to run on it, at the same prompt). You
@@ -469,7 +468,7 @@ actions and configure Embark so it knows that's the keymap you want.
 
 @enumerate
 @item
-@anchor{Telling Embark about commands that prompt for tabs by name}Telling Embark about commands that prompt for tabs by name
+Telling Embark about commands that prompt for tabs by name
 
 
 For step (1), it would be great if the @samp{tab-bar-mode} commands reported
@@ -481,7 +480,7 @@ with this.
 
 Maybe the easiest thing is to configure @uref{https://github.com/minad/marginalia, Marginalia} to enhance those
 commands. All of the @samp{tab-bar-*-tab-by-name} commands have the words
-``tab by name'' in the minibuffer prompt, so you can use:
+"tab by name" in the minibuffer prompt, so you can use:
 
 @lisp
 (add-to-list 'marginalia-prompt-categories '("tab by name" . tab))
@@ -533,7 +532,7 @@ the following advantages: you get the @samp{tab} category for all the
 commands, instead of defining new ones.
 
 @item
-@anchor{Defining and configuring a keymap for tab actions}Defining and configuring a keymap for tab actions
+Defining and configuring a keymap for tab actions
 
 
 Let's say we want to offer select, rename and close actions for tabs


### PR DESCRIPTION
See https://github.com/minad/consult/commit/cdc097d65e7b6d95daa187c9a7497679347c75bc. Simplifies the Embark-Consult integration a bit and seems like the cleaner solution overall. Please check if it works alright for you.
