### PR TITLE
Export to another window

### DIFF
--- a/embark-consult.el
+++ b/embark-consult.el
@@ -147,7 +147,7 @@ The elements of LINES are assumed to be values of category `consult-line'."
           (insert (concat lineno contents nl))))
       (goto-char (point-min))
       (occur-mode))
-    (switch-to-buffer buf)))
+    (pop-to-buffer buf)))
 
 (setf (alist-get 'consult-location embark-collect-initial-view-alist)
       'list)
@@ -169,7 +169,7 @@ The elements of LINES are assumed to be values of category `consult-line'."
       (grep-mode)
       (setq-local wgrep-header/footer-parser #'ignore)
       (when (fboundp 'wgrep-setup) (wgrep-setup)))
-    (switch-to-buffer buf)))
+    (pop-to-buffer buf)))
 
 (autoload 'compile-goto-error "compile")
 

--- a/embark-consult.el
+++ b/embark-consult.el
@@ -125,18 +125,18 @@ The elements of LINES are assumed to be values of category `consult-line'."
              ;; taken from occur-engine
              (lineno (propertize (format "%7d:" num)
                                  'occur-prefix t
-				 ;; Allow insertion of text at the end
+                                 ;; Allow insertion of text at the end
                                  ;; of the prefix (for Occur Edit mode).
-				 'front-sticky t
-				 'rear-nonsticky t
-				 'occur-target loc
-				 'follow-link t
-				 'help-echo mouse-msg))
+                                 'front-sticky t
+                                 'rear-nonsticky t
+                                 'occur-target loc
+                                 'follow-link t
+                                 'help-echo mouse-msg))
              (contents (propertize (embark-consult--strip line)
-				   'occur-target loc
+                                   'occur-target loc
                                    'occur-match t
-				   'follow-link t
-				   'help-echo mouse-msg))
+                                   'follow-link t
+                                   'help-echo mouse-msg))
              (nl (propertize "\n" 'occur-target loc))
              (this-buf (marker-buffer loc)))
           (unless (eq this-buf last-buf)

--- a/embark.el
+++ b/embark.el
@@ -1776,11 +1776,13 @@ buffer for each type of completion."
                    (let ((file (file-name-nondirectory path)))
                      (or (string= file ".") (string= file ".."))))
                  files)))
-  (dired (cons
-          ;; TODO: is it worth finding the deepest common containing directory?
-          (if (cl-every #'file-name-absolute-p files) "/" default-directory)
-          files))
-  (rename-buffer (format "*Embark Export Dired %s*" default-directory)))
+  (let ((buf (dired-noselect (cons
+                              ;; TODO: is it worth finding the deepest common containing directory?
+                              (if (cl-every #'file-name-absolute-p files) "/" default-directory)
+                              files))))
+    (with-current-buffer buf
+      (rename-buffer (format "*Embark Export Dired %s*" default-directory)))
+    (pop-to-buffer buf)))
 
 (autoload 'package-menu-mode "package")
 (autoload 'package-menu--generate "package")
@@ -1791,7 +1793,7 @@ buffer for each type of completion."
     (with-current-buffer buf
       (package-menu-mode)
       (package-menu--generate nil (mapcar #'intern packages)))
-    (switch-to-buffer buf)))
+    (pop-to-buffer buf)))
 
 (defvar bookmark-alist)
 


### PR DESCRIPTION
Most of the time when I use `embark-export`, I don't want the exported buffer to replace the one I'm using, and would rather it open in another window. What are your thoughts on a config option that sets this? If you approve I'll send in a PR that implements this, although it seems to me that each export command needs to be edited individually for this to work, which doesn't seem ideal.