### PR TITLE
Fix issue with displaying unescaped messages.

### DIFF
--- a/embark.el
+++ b/embark.el
@@ -610,7 +610,7 @@ a function to be called when the indicator is no longer needed."
                                (window-buffer mini) t t)))
             (overlay-put indicator-overlay 'before-string (concat ind " "))
             indicator-overlay)
-        (message ind))))))
+        (message (replace-string "%" "%%" ind)))))))
 
 (defun embark-keymap-prompter (keymap)
   "Let the user choose an action using the bindings in KEYMAP.


### PR DESCRIPTION
If the point under embark has %s in it, it will be interpreted as a format arg by message.  To fix this, we escape all "%", with "%%".