### PR TITLE
Various vindicator improvements

### DIFF
--- a/embark-consult.el
+++ b/embark-consult.el
@@ -240,8 +240,9 @@ actual type."
   :parent nil
   ("o" consult-outline)
   ("i" consult-imenu)
-  ("p" consult-project-imenu)
-  ("l" consult-line))
+  ("I" consult-imenu-project)
+  ("l" consult-line)
+  ("L" consult-line-multi))
 
 (embark-define-keymap embark-consult-async-search-map
   "Keymap for Consult async search commands"
@@ -250,7 +251,7 @@ actual type."
   ("r" consult-ripgrep)
   ("G" consult-git-grep)
   ("f" consult-find)
-  ("L" consult-locate))
+  ("F" consult-locate))
 
 (defvar embark-consult-search-map
   (keymap-canonicalize

--- a/embark.el
+++ b/embark.el
@@ -865,9 +865,10 @@ If NO-DEFAULT is t, no default value is passed to `completing-read'."
 (defvar embark--vindicator-prompt-buffer " *Embark Actions*"
   "Buffer used by `embark-verbose-indicator' to display actions and keybidings.")
 
-(defvar embark--vindicator-display-alist
-  `((,(regexp-quote embark--vindicator-prompt-buffer)
-     (display-buffer-reuse-window)))
+(defvar embark--vindicator-display-action
+  '(display-buffer-reuse-window)
+  ;;'(display-buffer-in-side-window (side . right))
+  ;;'(display-buffer-below-selected (window-height . 15))
   "Parameters added to `display-buffer-alist' for displaying the actions buffer.")
 
 (defvar embark--vindicator-excluded-commands
@@ -962,7 +963,9 @@ OTHER-TARGETS are other shadowed targets."
                                'string-greaterp (cddr descs))))
       (goto-char (point-min))
       (let ((display-buffer-alist
-             (append display-buffer-alist embark--vindicator-display-alist)))
+             (append display-buffer-alist
+                     `((,(regexp-quote embark--vindicator-prompt-buffer)
+                        ,@embark--vindicator-display-action)))))
         (pop-to-buffer (current-buffer) nil t)))
     (lambda ()
       (embark-kill-buffer-and-window embark--vindicator-prompt-buffer)

--- a/embark.el
+++ b/embark.el
@@ -906,11 +906,12 @@ OTHER-TARGETS are other shadowed targets."
       (add-face-text-property (point-min) (point) '(:height 1.1 :weight bold) 'append)
       (when other-targets
         ;; TODO make face customizable
-        (insert (propertize (format "Shadowed targets at point: %s\n"
+        (insert (propertize (format "Shadowed targets at point: %s (%s to cycle)\n"
                                     (string-join (mapcar (lambda (x)
                                                            (symbol-name (car x)))
                                                          other-targets)
-                                                 ", "))
+                                                 ", ")
+                                    (key-description (car (where-is-internal #'embark-cycle keymap))))
                             'face 'shadow)))
       (insert "\n")
       (dolist (binding bindings)

--- a/embark.el
+++ b/embark.el
@@ -878,6 +878,14 @@ If NO-DEFAULT is t, no default value is passed to `completing-read'."
     embark-keymap-help embark-become embark-isearch nil)
   "Commands not displayed by `embark-verbose-indicator'.")
 
+(defun embark--verbose-indicator-excluded-p (cmd)
+  "Return non-nil if CMD is excluded from the verbose indicator."
+  (seq-find (lambda (x)
+              (if (symbolp x)
+                  (eq cmd x)
+                (string-match-p x (symbol-name cmd))))
+            embark--verbose-indicator-excluded-commands))
+
 (defun embark-verbose-indicator (keymap target other-targets)
   "Action indicator that displays a list of all action key bindings.
 KEYMAP is the action keymap.
@@ -907,11 +915,7 @@ OTHER-TARGETS are other shadowed targets."
       (insert "\n")
       (dolist (binding bindings)
         (let ((cmd (caddr binding)))
-          (unless (seq-find (lambda (x)
-                              (if (symbolp x)
-                                  (eq cmd x)
-                                (string-match-p x (symbol-name cmd))))
-                            embark--verbose-indicator-excluded-commands)
+          (unless (embark--verbose-indicator-excluded-p cmd)
             (insert (format fmt (car binding))
                     (or (ignore-errors
                           (propertize (car (split-string (documentation cmd) "\n"))

--- a/embark.el
+++ b/embark.el
@@ -877,7 +877,11 @@ Used by `embark-verbose-indicator'.")
   "Buffer used by `embark-verbose-indicator' to display actions and keybidings.")
 
 (defvar embark--verbose-indicator-display-action
-  '(display-buffer-reuse-window)
+  `(display-buffer-reuse-window
+    (window-parameters
+     (mode-line-format
+      . ,(propertize " *Embark Actions*" 'face 'bold))))
+  ;;'(display-buffer-reuse-window)
   ;;'(display-buffer-in-side-window (side . right))
   ;;'(display-buffer-below-selected (window-height . 15))
   ;;'(display-buffer-below-selected (window-height . fit-window-to-buffer))
@@ -912,7 +916,9 @@ OTHER-TARGETS are other shadowed targets."
       (setq-local truncate-lines t)
       (setq-local buffer-read-only t)
       (erase-buffer)
-      (insert (format "Action for %s '%s'\n" (car target)
+      (insert (format "%s on %s '%s'\n"
+                      (propertize "Act" 'face 'highlight)
+                      (car target)
                       (embark--truncate-target (cdr target))))
       (add-face-text-property (point-min) (point)
                               'embark-verbose-indicator-title 'append)

--- a/embark.el
+++ b/embark.el
@@ -871,6 +871,7 @@ If NO-DEFAULT is t, no default value is passed to `completing-read'."
   '(display-buffer-reuse-window)
   ;;'(display-buffer-in-side-window (side . right))
   ;;'(display-buffer-below-selected (window-height . 15))
+  ;;'(display-buffer-below-selected (window-height . fit-window-to-buffer))
   "Parameters added to `display-buffer-alist' for displaying the actions buffer.")
 
 (defvar embark--verbose-indicator-excluded-commands


### PR DESCRIPTION
I just tried the new vindicator. It is a great addition and will be a good default, but we should polish it a little more. While playing around, I directly made some improvements (in my opinion):

- Truncate the target, such that it fits on a single line. This is important given that we have the defun target finder now. And more large target finders may come. (new function embark--truncate-target)
- Make the target the headline of the window
- Show shadowed targets below headline
- Support regexps in the exclude list
- Keybindings before command name for consistency with embark-bindings, reuse embark--formatted-bindings
- Reuse a window, this is a better fit for the verbose vertically arranged candidate list
- Do not hide the mode line, it is more instructive
- Remove the Selectrum-specific code
- Do not use read-only-mode, use inhibit-read-only

What do you think? cc @jaor