### PR TITLE
Customizable structure for verbose indicator buffer

### DIFF
--- a/embark.el
+++ b/embark.el
@@ -947,7 +947,7 @@ display actions and parameters are available."
   "List of sections to display in the verbose indicator buffer, in order.
 You can use either a symbol designating a concrete section, a string literal
 or a function that will take the list of targets, bindings and the cycle key
-and should insert at point anything it wants."
+and should return a string or list of strings to insert."
   :type '(repeat (choice (const :tag "Current target name" target)
                          (const :tag "List of other targets" other-targets)
                          (const :tag "Key bindings" bindings)
@@ -967,36 +967,39 @@ and should insert at point anything it wants."
                 (string-match-p x (symbol-name cmd))))
             embark-verbose-indicator-excluded-commands))
 
-(defun embark--verbose-indicator-insert-target (kind target)
-  "Insert the TARGET of kind KIND section in the indicator buffer."
-  (let ((target (if (eq kind 'embark-become)
-                    (concat (propertize "Become" 'face 'highlight))
-                  (format "%s on%s '%s'"
-                          (propertize "Act" 'face 'highlight)
-                          (if kind (format " %s" kind) "")
-                          (embark--truncate-target target))))
-        (p (point)))
-    (insert target)
-    (add-face-text-property p (point) 'embark-verbose-indicator-title 'append)))
+(defun embark--verbose-indicator-format-target (target)
+  "Format the TARGET section for the indicator buffer."
+  (let* ((kind (car target))
+         (result (if (eq kind 'embark-become)
+                     (concat (propertize "Become" 'face 'highlight))
+                   (format "%s on%s '%s'"
+                           (propertize "Act" 'face 'highlight)
+                           (if kind (format " %s" kind) "")
+                           (embark--truncate-target (cdr target))))))
+    (add-face-text-property 0 (length result)
+                            'embark-verbose-indicator-title
+                            'append
+                            result)
+    result))
 
-(defun embark--verbose-indicator-insert-cycle-key (cycle-key)
-  "Insert the CYCLE section in the indicator buffer."
-  (insert (propertize (format "(%s to cycle)" cycle-key)
-                      'face 'embark-verbose-indicator-shadowed)))
+(defun embark--verbose-indicator-format-cycle-key (cycle-key)
+  "Format the CYCLE section for the indicator buffer."
+  (propertize (format "(%s to cycle)" cycle-key)
+              'face 'embark-verbose-indicator-shadowed))
 
-(defun embark--verbose-indicator-insert-other-targets (targets)
-  "Insert the OTHER-TARGETS section in the indicator buffer."
-  (insert (propertize (string-join targets ", ")
-                      'face 'embark-verbose-indicator-shadowed)))
+(defun embark--verbose-indicator-format-other-targets (targets)
+  "Format the OTHER-TARGETS section for the indicator buffer."
+  (propertize (string-join targets ", ")
+              'face 'embark-verbose-indicator-shadowed))
 
-(defun embark--verbose-indicator-insert-bindings (bindings)
-  "Insert the BINDINGS section in the indicator buffer.
-MAX-WIDTH is the maximumb width of the command names."
+(defun embark--verbose-indicator-format-bindings (bindings)
+  "Format the BINDINGS section for the indicator buffer."
   (let* ((max-width (apply #'max (cons 0 (mapcar (lambda (x)
                                                   (string-width (car x)))
                                                 bindings))))
-         (fmt (format "%%-%ds" (1+ max-width))))
-    (dolist (binding bindings)
+         (fmt (format "%%-%ds" (1+ max-width)))
+         (result nil))
+    (dolist (binding bindings (nreverse result))
       (let ((cmd (caddr binding)))
         (unless (embark--verbose-indicator-excluded-p cmd)
           (let ((keys (format fmt (car binding)))
@@ -1004,7 +1007,23 @@ MAX-WIDTH is the maximumb width of the command names."
                        (propertize
                         (car (split-string (documentation cmd) "\n"))
                         'face 'embark-verbose-indicator-documentation))))
-            (insert keys (or doc "") "\n")))))))
+            (push (format "%s%s\n" keys (or doc "")) result)))))))
+
+(defun embark--verbose-indicator-format-section (section target targets bindings cycle)
+  "Convert the SECTION specification to a list of strings."
+  (let ((strs
+         (cond ((stringp section) section)
+               ((symbolp section)
+                (cl-case section
+                  (newline "\n")
+                  (target (embark--verbose-indicator-format-target target))
+                  (other-targets
+                   (embark--verbose-indicator-format-other-targets targets))
+                  (cycle (embark--verbose-indicator-format-cycle-key cycle))
+                  (bindings (embark--verbose-indicator-format-bindings bindings))
+                  (t (when (fboundp section)
+                       (funcall section (cons target targets) bindings cycle))))))))
+    (if (stringp strs) (list strs) strs)))
 
 (defun embark--verbose-indicator-update (keymap target targets)
   "Update verbose indicator buffer.
@@ -1012,25 +1031,19 @@ The arguments are the new KEYMAP, TARGET and other TARGETS."
   (with-current-buffer (get-buffer-create embark--verbose-indicator-buffer)
     (let* ((inhibit-read-only t)
            (bindings (car (embark--formatted-bindings keymap 'nested)))
-           (ck (let ((ck (where-is-internal #'embark-cycle keymap)))
-                 (and ck (key-description (car ck))))))
+           (cycle (let ((ck (where-is-internal #'embark-cycle keymap)))
+                    (and ck (key-description (car ck))))))
       (setq-local cursor-type nil)
       (setq-local truncate-lines t)
       (setq-local buffer-read-only t)
       (erase-buffer)
       (dolist (section embark-verbose-indicator-buffer-sections)
-        (cond ((stringp section) (insert section))
-              ((symbolp section)
-               (case section
-                 (newline (insert "\n"))
-                 (target
-                  (embark--verbose-indicator-insert-target (car target) (cdr target)))
-                 (other-targets
-                  (embark--verbose-indicator-insert-other-targets targets))
-                 (cycle (embark--verbose-indicator-insert-cycle-key ck))
-                 (bindings (embark--verbose-indicator-insert-bindings bindings))
-                 (t (when (fboundp section)
-                      (funcall section (cons target targets) bindings ck)))))))
+        (when-let (strs (embark--verbose-indicator-format-section section
+                                                                  target
+                                                                  targets
+                                                                  bindings
+                                                                  cycle))
+          (apply #'insert strs)))
       (goto-char (point-min)))))
 
 (defun embark-verbose-indicator (keymap targets)


### PR DESCRIPTION
We introduce the customizable list
embark-verbose-indicator-buffer-sections, which denotes the sections
to be included in the indicator buffer, in the user's desired order.
Besides symbols denoting specific sections (target, other-targets,
etc.), we allow the symbol newline and literal strings, which are
inserted, well, literally.

For each of the elements in the list there's a corresponding insertion
function, which users can advice to provide even more control on how
the sections are printed (we could define customization variables for
each inserter, but that seems to be, perhaps, too much).

The default value of embark-verbose-indicator-buffer-sections
reproduces the current structure.

As another example, i prefer the title to be below the
bindings (because i use bottom placement), put together the current
target and the alternative ones in the same line (i've got plenty of
horizontal space) and omit the cycle key indicator (i don't need that
reminder), so i've got

   '(bindings newline target "  " other-targets)

as the value of embark-verbose-indicator-buffer-sections.

Yes, newline is redundant (one can use the literal string "\n" with
the same effect), but it looks nicer in the customization buffer as a
symbolic choice.

An alternative that might be worth considering is using formatting
functions returning strings instead of inserters which write in the
buffer, specially if one wants to make them customizable (although a
bit of flexibility is lost that way if not).