### PR TITLE
Customization option for non-nested verbose indicator

### DIFF
--- a/embark.el
+++ b/embark.el
@@ -965,6 +965,10 @@ and should return a string or list of strings to insert."
                          (string :tag "Literal string")
                          (function :tag "Insertion function"))))
 
+(defcustom embark-verbose-indicator-nested t
+  "Whether the verbose indicator should use nested keymap navigation."
+  :type 'boolean)
+
 (defvar embark--verbose-indicator-buffer " *Embark Actions*"
   "Buffer used by `embark-verbose-indicator' to display actions and keybidings.")
 
@@ -1039,7 +1043,9 @@ and should return a string or list of strings to insert."
 The arguments are the new KEYMAP, TARGET and other TARGETS."
   (with-current-buffer (get-buffer-create embark--verbose-indicator-buffer)
     (let* ((inhibit-read-only t)
-           (bindings (car (embark--formatted-bindings keymap 'nested)))
+           (bindings (embark--formatted-bindings keymap
+                                                 embark-verbose-indicator-nested))
+           (bindings (car bindings))
            (cycle (let ((ck (where-is-internal #'embark-cycle keymap)))
                     (and ck (key-description (car ck))))))
       (setq-local cursor-type nil)
@@ -1073,8 +1079,9 @@ TARGETS is the list of targets."
         (select-window win))
       (lambda (prefix)
         (if prefix
-            (embark--verbose-indicator-update (lookup-key keymap prefix)
-                                              target other-targets)
+            (when embark-verbose-indicator-nested
+              (embark--verbose-indicator-update (lookup-key keymap prefix)
+                                                target other-targets))
           (quit-window 'kill-buffer indicator-window)
           (when-let (win (active-minibuffer-window))
             (select-window win)))))))


### PR DESCRIPTION
I prefer to see all composite keybindings at once, rather than
navigating to a submenu (and then perhaps regretting it).  Also, with
the availability of a custom bindings formatter, one can for instance
rearrange some of the composite keys in a separate column (this is me
again with my 270 columns wide vindicator buffer :)), indent them
differently, or play any other tricks with the full, linear list of
bindings if it's available.