### PR TITLE
Keep indicator alive when cycling

### DIFF
--- a/embark.el
+++ b/embark.el
@@ -488,6 +488,8 @@ There are three kinds:
 
 ;;; Core functionality
 
+(defconst embark--verbose-indicator-buffer " *Embark Actions*")
+
 (defun embark--metadata ()
   "Return current minibuffer completion metadata."
   (completion-metadata
@@ -789,7 +791,7 @@ UPDATE is the indicator update function."
        (let ((last-command-event (aref key 0))
              (minibuffer-scroll-window
               ;; NOTE: Here we special case the verbose indicator!
-              (or (get-buffer-window " *Embark Actions*" 'visible)
+              (or (get-buffer-window embark--verbose-indicator-buffer 'visible)
                   minibuffer-scroll-window)))
          (ignore-errors (command-execute cmd)))
        (embark-keymap-prompter keymap update))
@@ -1047,7 +1049,7 @@ SHADOWED-TARGETS is the list of other targets."
 (defun embark--verbose-indicator-update (keymap targets)
   "Update verbose indicator buffer.
 The arguments are the new KEYMAP and TARGETS."
-  (with-current-buffer (get-buffer-create " *Embark Actions*")
+  (with-current-buffer (get-buffer-create embark--verbose-indicator-buffer)
     (let* ((inhibit-read-only t)
            (bindings
             (embark--formatted-bindings keymap embark-verbose-indicator-nested))
@@ -1083,7 +1085,7 @@ The arguments are the new KEYMAP and TARGETS."
   "Indicator that displays a list of available key bindings."
   (lambda (&optional keymap targets prefix)
     (if (not keymap)
-        (when-let ((win (get-buffer-window " *Embark Actions*" 'visible)))
+        (when-let ((win (get-buffer-window embark--verbose-indicator-buffer 'visible)))
           (quit-window 'kill-buffer win))
       (embark--verbose-indicator-update
        (if (and prefix embark-verbose-indicator-nested)
@@ -1092,9 +1094,9 @@ The arguments are the new KEYMAP and TARGETS."
        targets)
       (let ((display-buffer-alist
              `(,@display-buffer-alist
-               (,(regexp-quote " *Embark Actions*")
+               (,(regexp-quote embark--verbose-indicator-buffer)
                 ,@embark-verbose-indicator-display-action))))
-        (display-buffer " *Embark Actions*")))))
+        (display-buffer embark--verbose-indicator-buffer)))))
 
 (defcustom embark-mixed-indicator-delay 0.5
   "Time in seconds after which the verbose indicator is shown.

--- a/embark.el
+++ b/embark.el
@@ -769,9 +769,6 @@ If CYCLE is non-nil bind `embark-cycle'."
       (when timer
         (cancel-timer timer)))))
 
-(defvar embark--verbose-indicator-buffer " *Embark Actions*"
-  "Buffer used by `embark-verbose-indicator' to display actions and keybidings.")
-
 (defun embark-keymap-prompter (keymap update)
   "Let the user choose an action using the bindings in KEYMAP.
 Besides the bindings in KEYMAP, the user is free to use all their
@@ -1084,24 +1081,20 @@ The arguments are the new KEYMAP and TARGETS."
 
 (defun embark-verbose-indicator ()
   "Indicator that displays a list of available key bindings."
-  (let ((indicator-window))
-    (lambda (&optional keymap targets prefix)
-      (if (not keymap)
-          (when-let ((win (get-buffer-window embark--verbose-indicator-buffer
-                                             'visible)))
-            (quit-window 'kill-buffer win))
-        (embark--verbose-indicator-update
-         (if (and prefix embark-verbose-indicator-nested)
-             (lookup-key keymap prefix)
-           keymap)
-         targets)
-        (unless indicator-window
-          (setq indicator-window
-                (let ((display-buffer-alist
-                       `(,@display-buffer-alist
-                         (,(regexp-quote " *Embark Actions*")
-                          ,@embark-verbose-indicator-display-action))))
-                  (display-buffer " *Embark Actions*"))))))))
+  (lambda (&optional keymap targets prefix)
+    (if (not keymap)
+        (when-let ((win (get-buffer-window " *Embark Actions*" 'visible)))
+          (quit-window 'kill-buffer win))
+      (embark--verbose-indicator-update
+       (if (and prefix embark-verbose-indicator-nested)
+           (lookup-key keymap prefix)
+         keymap)
+       targets)
+      (let ((display-buffer-alist
+             `(,@display-buffer-alist
+               (,(regexp-quote " *Embark Actions*")
+                ,@embark-verbose-indicator-display-action))))
+        (display-buffer " *Embark Actions*")))))
 
 (defcustom embark-mixed-indicator-delay 0.5
   "Time in seconds after which the verbose indicator is shown.


### PR DESCRIPTION
This is important for the vindicator which appears after some time. It should
not close when cycling.

WARNING: The indicator calling convention is changed again. I wouldn't guarantee that
it is the last time, so we should document that writing custom indicators is
currently an unstable feature.

As discussed in #310, https://github.com/oantolin/embark/issues/310#issuecomment-890003547