### PR TITLE
Use alists for the hooks, pass target and bounds to the hooks

### DIFF
--- a/README.org
+++ b/README.org
@@ -334,7 +334,7 @@ it, for all commands except those listed in =embark-skip-edit-commands=.
 ** Running some setup after injecting the target
 
 You can customize what happens after the target is inserted at the minibuffer
-prompt of an action. There are =embark-setup-hooks=, that are run by default
+prompt of an action. There are =embark-setup-action-hooks=, that are run by default
 after injecting the target into the minibuffer. The hook can be specified for
 specific action commands by associating the command to the desired hook. By
 default the hooks with the key t are executed.
@@ -343,7 +343,7 @@ For example, consider using =shell-command= as an action during file
 completion. It would be useful to insert a space before the target
 file name and to leave the point at the beginning, so you can
 immediately type the shell command. That's why in =embark='s default
-configuration there is an entry in =embark-setup-hooks= associating
+configuration there is an entry in =embark-setup-action-hooks= associating
 =shell-command= to =embark--shell-prep=, a simple helper command that
 quotes all the spaces in the file name, inserts an extra space at the
 beginning of the line and leaves point to the left of it.

--- a/embark-consult.el
+++ b/embark-consult.el
@@ -273,7 +273,7 @@ actual type."
 
 (defun embark-consult--unique-match (&rest _)
   "If there is a unique matching candidate, accept it.
-This is intended to be used in `embark-setup-hooks' for some
+This is intended to be used in `embark-setup-action-hooks' for some
 actions that are on `embark-allow-edit-commands'."
   ;; I couldn't quickly get this to work for ivy, so just skip ivy
   (unless (eq mwheel-scroll-up-function 'ivy-next-line)
@@ -285,11 +285,11 @@ actions that are on `embark-allow-edit-commands'."
 
 (dolist (cmd '(consult-outline consult-imenu consult-project-imenu))
   (cl-pushnew #'embark-consult--unique-match
-              (alist-get cmd embark-setup-hooks)))
+              (alist-get cmd embark-setup-action-hooks)))
 
 (defun embark-consult--accept-tofu (&rest _)
   "Accept input if it already has the unicode suffix.
-This is intended to be used in `embark-setup-hooks' for the
+This is intended to be used in `embark-setup-action-hooks' for the
 `consult-line' and `consult-outline' actions."
   (let* ((input (minibuffer-contents))
          (len (length input)))
@@ -301,11 +301,11 @@ This is intended to be used in `embark-setup-hooks' for the
 
 (dolist (cmd '(consult-line consult-outline))
   (cl-pushnew #'embark-consult--accept-tofu
-              (alist-get cmd embark-setup-hooks)))
+              (alist-get cmd embark-setup-action-hooks)))
 
 (defun embark-consult--add-async-separator (&rest _)
   "Add Consult's async separator at the beginning.
-This is intended to be used in `embark-setup-hooks' for any action
+This is intended to be used in `embark-setup-action-hooks' for any action
 that is a Consult async command."
   (let* ((style (alist-get consult-async-split-style
                            consult-async-split-styles-alist))
@@ -323,7 +323,7 @@ that is a Consult async command."
 (map-keymap
  (lambda (_key cmd)
    (cl-pushnew #'embark-consult--add-async-separator
-               (alist-get cmd embark-setup-hooks)))
+               (alist-get cmd embark-setup-action-hooks)))
  embark-consult-async-search-map)
 
 (provide 'embark-consult)

--- a/embark-consult.el
+++ b/embark-consult.el
@@ -271,7 +271,7 @@ actual type."
  (lambda (_key cmd) (cl-pushnew cmd embark-allow-edit-commands))
  embark-consult-search-map)
 
-(defun embark-consult--unique-match ()
+(defun embark-consult--unique-match (&rest _)
   "If there is a unique matching candidate, accept it.
 This is intended to be used in `embark-setup-hooks' for some
 actions that are on `embark-allow-edit-commands'."
@@ -287,7 +287,7 @@ actions that are on `embark-allow-edit-commands'."
   (cl-pushnew #'embark-consult--unique-match
               (alist-get cmd embark-setup-hooks)))
 
-(defun embark-consult--accept-tofu ()
+(defun embark-consult--accept-tofu (&rest _)
   "Accept input if it already has the unicode suffix.
 This is intended to be used in `embark-setup-hooks' for the
 `consult-line' and `consult-outline' actions."
@@ -303,9 +303,9 @@ This is intended to be used in `embark-setup-hooks' for the
   (cl-pushnew #'embark-consult--accept-tofu
               (alist-get cmd embark-setup-hooks)))
 
-(defun embark-consult--add-async-separator ()
+(defun embark-consult--add-async-separator (&rest _)
   "Add Consult's async separator at the beginning.
-This is intended to be used in `embark-setup-hook' for any action
+This is intended to be used in `embark-setup-hooks' for any action
 that is a Consult async command."
   (let* ((style (alist-get consult-async-split-style
                            consult-async-split-styles-alist))

--- a/embark.el
+++ b/embark.el
@@ -1420,9 +1420,6 @@ the target at point."
     (let* ((command embark--command)
            (prefix prefix-arg)
            (action-window (embark--target-window t))
-           (setup-hooks embark-setup-hooks)
-           (pre-hooks embark-pre-action-hooks)
-           (post-hooks embark-post-action-hooks)
            (allow-edit (if embark-allow-edit-default
                            (not (memq action embark-skip-edit-commands))
                          (memq action embark-allow-edit-commands)))
@@ -1430,7 +1427,7 @@ the target at point."
             (lambda ()
               (delete-minibuffer-contents)
               (insert (substring-no-properties target))
-              (embark--run-action-hooks setup-hooks action target bounds)
+              (embark--run-action-hooks embark-setup-hooks action target bounds)
               (unless allow-edit
                 (if (memq 'ivy--queue-exhibit post-command-hook)
                     ;; Ivy has special needs: (1) for file names
@@ -1457,18 +1454,21 @@ the target at point."
                                   (use-dialog-box nil)
                                   (last-nonmenu-event 13))
                               (setq prefix-arg prefix)
-                              (embark--run-action-hooks pre-hooks action target bounds)
+                              (embark--run-action-hooks embark-pre-action-hooks
+                                                        action target bounds)
                               (command-execute action))
                             (setq final-window (selected-window)))
-                        (embark--run-action-hooks post-hooks action target bounds)
+                        (embark--run-action-hooks embark-post-action-hooks
+                                                  action target bounds)
                         (when dedicate (set-window-dedicated-p dedicate nil)))
                       (unless (eq final-window action-window)
                         (select-window final-window)))))
               (lambda ()
                 (with-selected-window action-window
-                  (embark--run-action-hooks pre-hooks action target bounds)
+                  (embark--run-action-hooks embark-pre-action-hooks action target bounds)
                   (unwind-protect (funcall action target)
-                    (embark--run-action-hooks post-hooks action target bounds)))))))
+                    (embark--run-action-hooks embark-post-action-hooks
+                                              action target bounds)))))))
       (if (not (and quit (minibufferp)))
           (funcall run-action)
         (embark--quit-and-run run-action)))))

--- a/embark.el
+++ b/embark.el
@@ -361,7 +361,7 @@ target bounds. The default pre-action hook is specified by the
 entry with key t. Furthermore hooks with the key :always are
 executed always."
   :type '(alist :key-type
-                (choice command
+                (choice symbol
                         (const :tag "Default" t)
                         (const :tag "Always" :always))
                 :value-type hook))
@@ -381,7 +381,7 @@ and the target bounds. The default pre-action hook is specified
 by the entry with key t. Furthermore hooks with the key :always
 are executed always."
   :type '(alist :key-type
-                (choice command
+                (choice symbol
                         (const :tag "Default" t)
                         (const :tag "Always" :always))
                 :value-type hook))
@@ -394,7 +394,7 @@ and the target bounds. The default post-action hook is specified
 by the entry with key t. Furthermore hooks with the key :always
 are executed always."
   :type '(alist :key-type
-                (choice command
+                (choice symbol
                         (const :tag "Default" t)
                         (const :tag "Always" :always))
                 :value-type hook))

--- a/embark.el
+++ b/embark.el
@@ -363,6 +363,7 @@ This list is used only when `embark-allow-edit-default' is t."
   '((write-region . embark--ignore-target)
     (append-to-file . embark--ignore-target)
     (indent-pp-sexp . embark--beginning-of-target)
+    (backward-up-list . embark--beginning-of-target)
     (raise-sexp . embark--beginning-of-target)
     (kill-sexp . embark--beginning-of-target)
     (mark-sexp . embark--beginning-of-target))

--- a/embark.el
+++ b/embark.el
@@ -358,12 +358,12 @@ corresponding value as a setup hook after injecting the target
 into in the minibuffer and before acting on it. The hooks must
 accept three arguments, the action, the target string and the
 target bounds. The default pre-action hook is specified by the
-entry with key t. Furthermore hooks with the key nil are executed
-always."
+entry with key t. Furthermore hooks with the key :always are
+executed always."
   :type '(alist :key-type
                 (choice command
                         (const :tag "Default" t)
-                        (const :tag "Always" nil))
+                        (const :tag "Always" :always))
                 :value-type hook))
 
 (defcustom embark-pre-action-hooks
@@ -378,12 +378,12 @@ always."
 The hooks are run right before an action is embarked upon. The
 hooks must accept three arguments, the action, the target string
 and the target bounds. The default pre-action hook is specified
-by the entry with key t. Furthermore hooks with the key nil are
-executed always."
+by the entry with key t. Furthermore hooks with the key :always
+are executed always."
   :type '(alist :key-type
                 (choice command
                         (const :tag "Default" t)
-                        (const :tag "Always" nil))
+                        (const :tag "Always" :always))
                 :value-type hook))
 
 (defcustom embark-post-action-hooks nil
@@ -391,12 +391,12 @@ executed always."
 The hooks are run after an embarked upon action concludes. The
 hooks must accept three arguments, the action, the target string
 and the target bounds. The default post-action hook is specified
-by the entry with key t. Furthermore hooks with the key nil are
-executed always."
+by the entry with key t. Furthermore hooks with the key :always
+are executed always."
   :type '(alist :key-type
                 (choice command
                         (const :tag "Default" t)
-                        (const :tag "Always" nil))
+                        (const :tag "Always" :always))
                 :value-type hook))
 
 (defcustom embark-repeat-commands
@@ -1397,14 +1397,14 @@ queued most recently to the one queued least recently."
 
 (defun embark--run-action-hooks (hooks action &rest args)
   "Run HOOKS for ACTION with ARGS.
-The HOOKS argument must be an alist. The keys t and nil are
-treated specially. The nil hooks are executed always and the
+The HOOKS argument must be an alist. The keys t and :always are
+treated specially. The :always hooks are executed always and the
 t hooks are the default hooks, if there are no command-specific
 hooks."
   (let ((embark--action-hook (or (alist-get action hooks)
                                  (alist-get t hooks))))
     (apply #'run-hook-with-args 'embark--action-hook action args))
-  (let ((embark--action-hook (alist-get nil hooks)))
+  (let ((embark--action-hook (alist-get :always hooks)))
     (apply #'run-hook-with-args 'embark--action-hook action args)))
 
 (defun embark--act (action target bounds &optional quit)

--- a/embark.el
+++ b/embark.el
@@ -347,7 +347,7 @@ This list is used only when `embark-allow-edit-default' is nil."
 This list is used only when `embark-allow-edit-default' is t."
   :type '(repeat symbol))
 
-(defcustom embark-setup-hooks
+(defcustom embark-setup-action-hooks
   '((async-shell-command embark--shell-prep)
     (shell-command embark--shell-prep)
     (pp-eval-expression embark--eval-prep)
@@ -1427,7 +1427,8 @@ the target at point."
             (lambda ()
               (delete-minibuffer-contents)
               (insert (substring-no-properties target))
-              (embark--run-action-hooks embark-setup-hooks action target bounds)
+              (embark--run-action-hooks embark-setup-action-hooks
+                                        action target bounds)
               (unless allow-edit
                 (if (memq 'ivy--queue-exhibit post-command-hook)
                     ;; Ivy has special needs: (1) for file names

--- a/embark.texi
+++ b/embark.texi
@@ -420,7 +420,7 @@ it, for all commands except those listed in @samp{embark-skip-edit-commands}.
 @section Running some setup after injecting the target
 
 You can customize what happens after the target is inserted at the minibuffer
-prompt of an action. There are @samp{embark-setup-hooks}, that are run by default
+prompt of an action. There are @samp{embark-setup-action-hooks}, that are run by default
 after injecting the target into the minibuffer. The hook can be specified for
 specific action commands by associating the command to the desired hook. By
 default the hooks with the key t are executed.
@@ -429,7 +429,7 @@ For example, consider using @samp{shell-command} as an action during file
 completion. It would be useful to insert a space before the target
 file name and to leave the point at the beginning, so you can
 immediately type the shell command. That's why in @samp{embark}'s default
-configuration there is an entry in @samp{embark-setup-hooks} associating
+configuration there is an entry in @samp{embark-setup-action-hooks} associating
 @samp{shell-command} to @samp{embark--shell-prep}, a simple helper command that
 quotes all the spaces in the file name, inserts an extra space at the
 beginning of the line and leaves point to the left of it.


### PR DESCRIPTION
Using alist for hooks seems like a good solution. We end up with generic pre-action hooks: embark--ignore-target and embark-beginning-of-target. Furthermore we can get rid of the target bounds variable again. Or shall we keep the dynamically bound variable such that the hooks don't have to take an argument?

As discussed in https://github.com/oantolin/embark/commit/c8125e65350ec7e931d4687998fae53fbd4c95d2.