### PR TITLE
C-g is bound to #'abort-minibuffers in Emacs 28

### DIFF
--- a/embark.el
+++ b/embark.el
@@ -950,7 +950,7 @@ UPDATE is the indicator update function."
        (embark-keymap-prompter keymap update))
       ((guard (lookup-key keymap key))  ; if directly bound, then obey
        cmd)
-      ((or 'minibuffer-keyboard-quit 'abort-recursive-edit)
+      ((or 'minibuffer-keyboard-quit 'abort-recursive-edit 'abort-minibuffers)
        nil)
       ('self-insert-command
        (minibuffer-message "Not an action")


### PR DESCRIPTION
Support C-g on GNU Emacs 28.

Btw, would it be OK with you if we send such small patches to your e-mail? For
me personally, it's kind of an overkill to open a web browser and click stuff
just to propose a simple one-line change.

(Obviously, I'd only use e-mail if I'm 100% sure that the patch is trivial
enough to not require any discussion.)
