### PR TITLE
Don't shadow `pp-eval-expression` binding in `embark-defun-map`

### DIFF
--- a/embark.el
+++ b/embark.el
@@ -3337,8 +3337,7 @@ and leaves the point to the left of it."
 (embark-define-keymap embark-defun-map
   "Keymap for Embark defun actions."
   :parent embark-expression-map
-  ("RET" eval-defun)
-  ("e" eval-defun)
+  ("d" eval-defun)
   ("c" compile-defun)
   ("l" elint-defun)
   ("D" edebug-defun)


### PR DESCRIPTION
Change the binding of `eval-defun` from `e` to `d` in
`embark-defun-map` and remove its binding to `RET`. This change
unshadows the bindings of `pp-eval-expression` in the parent
`embark-expression-map`.

Top level expressions are categorized as defuns instead, and it is
useful to be able to call `pp-eval-expression` on them, which also
does the right thing for defuns. Usually, `eval-defun` is only needed
to instrument a function for edebug (using a prefix argument). This
use case is already covered by the existing `D` binding to
`edebug-defun`.

The only other reason to call `eval-defun` on top-level forms is to
reset variables defined via `defvar` or `defcustom`. The `d` binding
is provided for these cases.