### PR TITLE
Extend the embark url target to find shr urls

### DIFF
--- a/embark.el
+++ b/embark.el
@@ -674,9 +674,10 @@ In `dired-mode', it uses `dired-get-filename' instead."
     (when-let ((url (or (get-text-property (point) 'shr-url)
                         (get-text-property (point) 'image-url))))
       `(url ,url
-            . ,(cons (previous-single-property-change
-                      (min (1+ (point)) (point-max)) 'mouse-face)
-                     (next-single-property-change (point) 'mouse-face))))))
+            ,(previous-single-property-change
+              (min (1+ (point)) (point-max)) 'mouse-face nil (point-min))
+            . ,(next-single-property-change
+                (point) 'mouse-face nil (point-max))))))
 
 (declare-function widget-at "wid-edit")
 


### PR DESCRIPTION
This is useful when running embark-act on links in shr buffers: webpages, elfeed buffers, mail buffers etc. If the point is on an image and the image is not a link, the image url is found instead.

It's actually possible to find the bounds of the shr url correctly with `(next-single-property-change (point) 'mouse-face)`, but I haven't added it yet. Do you think it'll be useful?

EDIT: I added the bounds.