### PR TITLE
keymap-prompter: fix persistence of digit-argument overriding map

### DIFF
--- a/embark.el
+++ b/embark.el
@@ -1003,7 +1003,9 @@ UPDATE is the indicator update function."
          (embark-completing-read-prompter prefix-map update)))
       ((or 'universal-argument 'negative-argument 'digit-argument)
        (let ((last-command-event (aref keys 0)))
-         (command-execute cmd))
+         ;; Prevent `digit-argument' from modifying the overriding map
+         (let ((overriding-terminal-local-map overriding-terminal-local-map))
+           (command-execute cmd)))
        (embark-keymap-prompter keymap update))
       ((guard (lookup-key keymap keys))  ; if directly bound, then obey
        cmd)


### PR DESCRIPTION
This fixes the following bug:

To insert the keybinding of the command next-line:
1) M-x next-line
2) C-. (embark-act)
3) C-u b (where-is with universal argument)
Pressing a number immediately after this will not insert this number, it will
interpret it as a digit argument instead.
