### PR TITLE
Allow binding abort-recursive-edit in embark maps

### DIFF
--- a/embark.el
+++ b/embark.el
@@ -1007,10 +1007,10 @@ UPDATE is the indicator update function."
          (let ((overriding-terminal-local-map overriding-terminal-local-map))
            (command-execute cmd)))
        (embark-keymap-prompter keymap update))
-      ((guard (lookup-key keymap keys))  ; if directly bound, then obey
-       cmd)
       ((or 'minibuffer-keyboard-quit 'abort-recursive-edit 'abort-minibuffers)
        nil)
+      ((guard (lookup-key keymap keys))  ; if directly bound, then obey
+       cmd)
       ('self-insert-command
        (minibuffer-message "Not an action")
        (embark-keymap-prompter keymap update))


### PR DESCRIPTION
This reorders two clauses in a `cond` with the following consequence: one can
now bind `abort-recursive-edit` to a key like `<escape>` in an embark map and
then use this key to cancel embark.

Current behaviour without this patch is that by pressing `<escape>`, embark
will throw your minibuffer away and literally execute `abort-recursive-edit`
like any other action, which is rarely useful and usually just signals an
error.
