### PR TITLE
Remove from history and minor changes

### DIFF
--- a/embark-consult.el
+++ b/embark-consult.el
@@ -322,6 +322,7 @@ that is a Consult async command."
   "Collect all imenu items in the current buffer."
   (cons 'imenu (mapcar #'car (consult-imenu--items))))
 
+(setf (alist-get 'imenu embark-default-action-overrides) #'consult-imenu)
 (add-to-list 'embark-candidate-collectors #'embark-consult-outline-candidates 'append)
 
 (provide 'embark-consult)

--- a/embark-consult.el
+++ b/embark-consult.el
@@ -317,13 +317,10 @@ that is a Consult async command."
   "Collect all outline headings in the current buffer."
   (cons 'consult-location (consult--outline-candidates)))
 
+(autoload 'consult-imenu--items "consult-imenu")
 (defun embark-consult-toc-imenu ()
   "Collect all imenu items in the current buffer."
-  (cons 'consult-location
-        (mapcar (pcase-lambda (`(,item . ,pos))
-                  (propertize item 'consult-location
-                              (cons pos (line-number-at-pos pos))))
-                (consult-imenu--items))))
+  (cons 'imenu (mapcar #'car (consult-imenu--items))))
 
 (add-to-list 'embark-candidate-collectors #'embark-consult-toc-outline 'append)
 

--- a/embark-consult.el
+++ b/embark-consult.el
@@ -313,22 +313,19 @@ that is a Consult async command."
 
 ;;; Tables of contents for buffers: imenu and outline candidate collectors
 
-
 (defun embark-consult-toc-outline ()
-  "Collect all outline headings in the current buffer." 
+  "Collect all outline headings in the current buffer."
   (cons 'consult-location (consult--outline-candidates)))
 
 (defun embark-consult-toc-imenu ()
-  "Collect all imenu items in the current buffer." 
+  "Collect all imenu items in the current buffer."
   (cons 'consult-location
         (mapcar (pcase-lambda (`(,item . ,pos))
                   (propertize item 'consult-location
                               (cons pos (line-number-at-pos pos))))
                 (consult-imenu--items))))
 
-(unless (memq 'embark-consult-toc-outline embark-candidate-collectors)
-  (setq embark-candidate-collectors
-        (append embark-candidate-collectors '(embark-consult-toc-outline))))
+(add-to-list 'embark-candidate-collectors #'embark-consult-toc-outline 'append)
 
 (provide 'embark-consult)
 ;;; embark-consult.el ends here

--- a/embark-consult.el
+++ b/embark-consult.el
@@ -313,16 +313,16 @@ that is a Consult async command."
 
 ;;; Tables of contents for buffers: imenu and outline candidate collectors
 
-(defun embark-consult-toc-outline ()
+(defun embark-consult-outline-candidates ()
   "Collect all outline headings in the current buffer."
   (cons 'consult-location (consult--outline-candidates)))
 
 (autoload 'consult-imenu--items "consult-imenu")
-(defun embark-consult-toc-imenu ()
+(defun embark-consult-imenu-candidates ()
   "Collect all imenu items in the current buffer."
   (cons 'imenu (mapcar #'car (consult-imenu--items))))
 
-(add-to-list 'embark-candidate-collectors #'embark-consult-toc-outline 'append)
+(add-to-list 'embark-candidate-collectors #'embark-consult-outline-candidates 'append)
 
 (provide 'embark-consult)
 ;;; embark-consult.el ends here

--- a/embark.el
+++ b/embark.el
@@ -472,6 +472,7 @@ arguments and more details."
     (bookmark-rename embark--restart)
     (delete-file embark--restart)
     (embark-recentf-remove embark--restart)
+    (embark-history-remove embark--restart)
     (rename-file embark--restart)
     (copy-file embark--restart)
     (delete-directory embark--restart)
@@ -1141,7 +1142,7 @@ If NESTED is non-nil subkeymaps are not flattened."
 
 (defun embark-completing-read-prompter (keymap update &optional no-default)
   "Prompt via completion for a command bound in KEYMAP.
-If NO-DEFAULT is t, no default value is passed to`completing-read'. 
+If NO-DEFAULT is t, no default value is passed to`completing-read'.
 
 UPDATE is the indicator update function.  It is not used directly
 here, but if the user switches to `embark-keymap-prompter', the
@@ -3104,7 +3105,24 @@ When called with a prefix argument OTHER-WINDOW, open dired in other window."
 (defun embark-recentf-remove (file)
   "Remove FILE from the list of recent files."
   (interactive (list (completing-read "Remove recent file: " recentf-list nil t)))
+  (embark-history-remove file)
   (setq recentf-list (delete (expand-file-name file) recentf-list)))
+
+(defun embark-history-remove (str)
+  "Remove STR from `minibuffer-history-variable'.
+Many completion UIs sort by history position.  This command can be used
+to remove entries from the history, such that they are not sorted closer
+to the top."
+  (interactive
+   (list
+    (completing-read "Remove history item: "
+                     (if (eq minibuffer-history-variable t)
+                         (user-error "No minibuffer history")
+                       (symbol-value minibuffer-history-variable))
+                     nil t)))
+  (unless (eq minibuffer-history-variable t)
+    (set minibuffer-history-variable
+         (delete str (symbol-value minibuffer-history-variable)))))
 
 (defvar xref-backend-functions)
 
@@ -3443,7 +3461,7 @@ and leaves the point to the left of it."
   ("=" ediff-files)
   ("e" embark-eshell)
   ("+" make-directory)
-  ("-" embark-recentf-remove)
+  ("\\" embark-recentf-remove)
   ("I" embark-insert-relative-path)
   ("W" embark-save-relative-path)
   ("l" load-file)
@@ -3532,7 +3550,8 @@ and leaves the point to the left of it."
   ("e" pp-eval-expression)
   ("a" apropos)
   ("n" embark-next-symbol)
-  ("p" embark-previous-symbol))
+  ("p" embark-previous-symbol)
+  ("\\" embark-history-remove))
 
 (embark-define-keymap embark-face-map
   "Keymap for Embark face actions."


### PR DESCRIPTION
I know you don't use UIs which sort, but for some people this matters. ;)

Sometimes I accidentally execute some command which is then sorted closer to the top. I added a command `embark-history-remove`, which allows to remove the candidate from the minibuffer history. This command is similar to `embark-recentf-remove`. I wasn't so bold to put this command into the general map. Instead I put it into the symbol map, but one could be even more conservative and only put it in the command map. I am mostly bothered by this for M-x.

I changed the keybindings to backslash, which is better since it avoids the conflict with the reserved "-" binding. Furthermore I feel the `embark-recentf-remove` and `embark-history-remove` commands are not important enough to put them on "-".

If you are not convinced - a more important use case: If you played `tetris` for a while, it is better to remove the command afterwards from the history. The next time you demonstrate something with your Emacs everybody is convinced that you use the editor only for serious work. Unfortunately this problem is more severe for poor guys who use in-your-face UIs like Vertico. Damn.
