### PR TITLE
Remove occur-highlight-regexp

### DIFF
--- a/embark-consult.el
+++ b/embark-consult.el
@@ -155,8 +155,7 @@ The elements of LINES are assumed to be values of category `consult-line'."
             (setq last-buf this-buf))
           (insert (concat lineno contents nl))))
       (goto-char (point-min))
-      (occur-mode)
-      (setq-local occur-highlight-regexp "^.*$"))
+      (occur-mode))
     (pop-to-buffer buf)))
 
 (setf (alist-get 'consult-location embark-collect-initial-view-alist)


### PR DESCRIPTION
This variable is neither present on Emacs 27 nor 28.