### PR TITLE
Instead of a serialization check, overwrite `read`

### DIFF
--- a/embark.el
+++ b/embark.el
@@ -2904,16 +2904,22 @@ PRED is a predicate function used to filter the items."
 
 (defun embark-export-customize-variable (variables)
   "Create a customization buffer listing VARIABLES."
-  (embark--export-customize
-   variables "Variables" 'custom-variable
-   (lambda (sym)
-     (and (boundp sym)
-          (condition-case nil
-              ;; Check if variable can be properly deserialized.
-              ;; The customization widget relies on this.
-              (let ((val (symbol-value sym)))
-                (or (read (format "%S" val)) t))
-            (t nil))))))
+  ;; The widget library serializes/deserializes the values.
+  ;; We advise the serialization in order to avoid errors for nonserializable variables.
+  (cl-letf* ((ht (make-hash-table :test #'equal))
+             (orig-read (symbol-function #'read))
+             (orig-write (symbol-function #'widget-sexp-value-to-internal))
+             ((symbol-function #'read)
+              (lambda (&optional str)
+                (condition-case nil
+                    (funcall orig-read str)
+                  (error (gethash str ht)))))
+             ((symbol-function #'widget-sexp-value-to-internal)
+              (lambda (widget val)
+                (let ((str (funcall orig-write widget val)))
+                  (puthash str val ht)
+                  str))))
+    (embark--export-customize variables "Variables" 'custom-variable #'boundp)))
 
 (defun embark-export-ibuffer (buffers)
   "Create an ibuffer buffer listing BUFFERS."


### PR DESCRIPTION
I thought again about #410. It seems to me that the approach used here is better. It is more performant and variables are not filtered out unexpectedly. But it seems that the effect is that nonserializable variables are displayed as "EDITED", so maybe this has other bad side effects.

(EDIT: Downside is now that we cannot save the widget view anymore because of this edited display. Hmm.)