### PR TITLE
Some improvements to embark-act-all

### DIFF
--- a/embark.el
+++ b/embark.el
@@ -2004,6 +2004,8 @@ ARG is the prefix argument."
           (or (cl-mapcar
                (lambda (cand orig-cand)
                  (list :type type :orig-type orig-type
+                       ;; TODO The file special casing here seems odd.
+                       ;; Why do we need this?
                        :target (if (eq type 'file) (expand-file-name cand dir) cand)
                        :orig-target orig-cand))
                (plist-get transformed :candidates)
@@ -2016,11 +2018,12 @@ ARG is the prefix argument."
                      indicators (embark--action-keymap type nil)
                      (list (list :type type :multi (length candidates))))
                     (user-error "Canceled")))
+               (post-action-wo-restart
+                (mapcar (lambda (x) (remq 'embark--restart x))
+                        embark-post-action-hooks))
                (act (lambda (candidate)
                       (let ((embark-allow-edit-actions nil)
-                            (embark-post-action-hooks
-                             (mapcar (lambda (x) (remq 'embark--restart x))
-                                     embark-post-action-hooks)))
+                            (embark-post-action-hooks post-action-wo-restart))
                         (embark--act action candidate)))))
           (when (and (eq action (embark--default-action type))
                      (eq action embark--command))

--- a/embark.el
+++ b/embark.el
@@ -3747,8 +3747,8 @@ and leaves the point to the left of it."
 (embark-define-keymap embark-function-map
   "Keymap for Embark function actions."
   :parent embark-symbol-map
-  ("s" elp-instrument-function) ;; s like statistics
-  ("S" 'elp-restore-function) ;; quoted, not autoloaded
+  ("m" elp-instrument-function) ;; m=measure
+  ("M" 'elp-restore-function) ;; quoted, not autoloaded
   ("t" trace-function)
   ("T" 'untrace-function)) ;; quoted, not autoloaded
 
@@ -3771,8 +3771,8 @@ and leaves the point to the left of it."
   ("W" embark-save-package-url)
   ("a" package-autoremove)
   ("g" package-refresh-contents)
-  ("s" elp-instrument-package)
-  ("S" embark-elp-restore-package))
+  ("m" elp-instrument-package) ;; m=measure
+  ("M" embark-elp-restore-package))
 
 (embark-define-keymap embark-bookmark-map
   "Keymap for Embark bookmark actions."

--- a/embark.el
+++ b/embark.el
@@ -1093,6 +1093,8 @@ UPDATE is the indicator update function."
        (embark-keymap-prompter keymap update))
       ('execute-extended-command
        (intern-soft (read-extended-command)))
+      ((or 'keyboard-quit 'keyboard-escape-quit)
+       nil)
       (_ cmd))))
 
 (defun embark--command-name (cmd)


### PR DESCRIPTION
I tested embark-act-all and it seems to work well overall. I've observed a few minor issues and improved them in this PR.

1. Quitting did not work properly with the keymap prompter
2. The indicator can do a bit better, showing Act* instead of Act
3. (Unrelated) we should not use S for elp, since this conflicts with snapshot
4. Maybe we can clean up the functions a little bit better. I applied a few minor refactorings as a start.