### PR TITLE
Support generic multi-category

### DIFF
--- a/embark-consult.el
+++ b/embark-consult.el
@@ -201,19 +201,6 @@ The elements of LINES are assumed to be values of category `consult-line'."
 (setf (alist-get 'consult-grep embark-collect-initial-view-alist)
       'list)
 
-;;; Support for consult-multi
-
-(defun embark-consult--multi-transform (_type target)
-  "Refine `consult-multi' TARGET to its real type.
-This function takes a target of type `consult-multi' (from
-Consult's `consult-multi' category) and transforms it to its
-actual type."
-  (or (get-text-property 0 'consult-multi target)
-      (cons 'general target)))
-
-(setf (alist-get 'consult-multi embark-transformer-alist)
-      #'embark-consult--multi-transform)
-
 ;;; Support for consult-isearch
 
 (setf (alist-get 'consult-isearch embark-transformer-alist)

--- a/embark.el
+++ b/embark.el
@@ -178,7 +178,10 @@ bounds pair of the target at point for highlighting."
     (symbol . embark--refine-symbol-type)
     (embark-keybinding . embark--keybinding-command)
     (project-file . embark--project-file-full-path)
-    (package . embark--remove-package-version))
+    (package . embark--remove-package-version)
+    (multi-category . embark--refine-multi-category)
+    ;; TODO: `consult-multi' has been obsoleted by `multi-category'. Remove!
+    (consult-multi . embark--refine-multi-category))
   "Alist associating type to functions for transforming targets.
 Each function should take a type and a target string and return a
 pair of the form a `cons' of the new type and the new target."
@@ -1818,6 +1821,13 @@ minibuffer before executing the action."
                       (embark--run-action-hooks embark-post-action-hooks
                                                 action target quit))))))))
       (if quit (embark--quit-and-run run-action) (funcall run-action)))))
+
+(defun embark--refine-multi-category (_type target)
+  "Refine `multi-category' TARGET to its actual type."
+  (or (get-text-property 0 'multi-category target)
+      ;; TODO: `consult-multi' has been obsoleted by `multi-category'. Remove!
+      (get-text-property 0 'consult-multi target)
+      (cons 'general target)))
 
 (defun embark--refine-symbol-type (_type target)
   "Refine symbol TARGET to command or variable if possible."


### PR DESCRIPTION
The consult-multi category can be useful for other packages besides
Consult. For example the Citar package has a completion command which
offers both files and urls. We keep consult-multi support for a short
transition period.

See also https://github.com/minad/marginalia/pull/119 and https://github.com/minad/consult/pull/488

Omar, what do you think about the proposed generalization? Also we may want to start a name bikeshedding discussion. ;)