### PR TITLE
Don't quit by default when an unexpected key is pressed

### DIFF
--- a/embark.el
+++ b/embark.el
@@ -1998,16 +1998,14 @@ target."
     (unwind-protect
         (while
             (let* ((target (car targets))
+                   (keymap (let ((embark-default-action-overrides
+                                  (if default-done
+                                      `((t . ,default-done))
+                                    embark-default-action-overrides)))
+                             (embark--action-keymap (plist-get target :type)
+                                                    (cdr targets))))
                    (action
-                    (or (embark--prompt
-                         indicators
-                         (let ((embark-default-action-overrides
-                                (if default-done
-                                    `((t . ,default-done))
-                                  embark-default-action-overrides)))
-                           (embark--action-keymap (plist-get target :type)
-                                                  (cdr targets)))
-                         targets)
+                    (or (embark--prompt indicators keymap targets)
                         (user-error "Canceled")))
                    (default-action (or default-done
                                        (embark--default-action
@@ -2032,7 +2030,14 @@ target."
                                 (eq action embark--command))
                            (embark--orig-target target)
                          target)
-                       (if embark-quit-after-action (not arg) arg))
+                       (xor
+                        ;; reverse the quitting behavior
+                        arg
+                        (and embark-quit-after-action
+                             (member action
+                                     (cl-loop
+                                      for (_ . cmd) in (embark--all-bindings keymap)
+                                      collect cmd)))))
                     (user-error
                      (funcall (if repeat #'message #'user-error)
                               "%s" (cadr err))))


### PR DESCRIPTION
Fixes #448 by introducing `embark-quit-other-actions` (default to `t`).

Set it to `nil` to prevent quitting.