### PR TITLE
Remove grid view support (Fix #473)

### DIFF
--- a/README.org
+++ b/README.org
@@ -157,8 +157,7 @@ sets:
 
 - The =embark-collect= command produces a buffer listing all the current
   candidates, for you to peruse and run actions on at your leisure.
-  The candidates can be viewed in a grid or as a list showing
-  additional annotations.
+  The candidates are displayed as a list showing additional annotations.
 
   The Embark Collect buffer is "dired-like": you can mark and unmark
   candidates with =m= and =u=, you can unmark all marked candidates with =U=

--- a/embark-consult.el
+++ b/embark-consult.el
@@ -164,8 +164,6 @@ This function is meant to be added to `embark-collect-mode-hook'."
       (mapc (lambda (x) (consult--get-location (funcall fn x)))
             embark-collect--candidates))))
 
-(setf (alist-get 'consult-location embark-collect-initial-view-alist)
-      'list)
 (setf (alist-get 'consult-location embark-exporters-alist)
       #'embark-consult-export-occur)
 (cl-pushnew #'embark-consult--upgrade-markers embark-collect-mode-hook)
@@ -205,8 +203,6 @@ This function is meant to be added to `embark-collect-mode-hook'."
       #'embark-consult-goto-grep)
 (setf (alist-get 'consult-grep embark-exporters-alist)
       #'embark-consult-export-grep)
-(setf (alist-get 'consult-grep embark-collect-initial-view-alist)
-      'list)
 
 ;;; Support for consult-isearch
 


### PR DESCRIPTION
- See #473 for the reasoning.
- Introduce the embark-collect-zebra-types configuration variable.
- Remove the zebra mode lighter. Lighters seem unnecessary for visual modes like
  hl-line-mode.