### PR TITLE
Add align-regexp to embark-target-injection-hooks

### DIFF
--- a/embark.el
+++ b/embark.el
@@ -415,6 +415,7 @@ entry of `embark-target-injection-hooks' whose key is the action."
     (eval-last-sexp embark--ignore-target)
     (embark-eval-replace embark--ignore-target)
     ;; commands which prompt for something that is *not* the target
+    (align-regexp embark--ignore-target)
     (write-region embark--ignore-target)
     (append-to-file embark--ignore-target)
     (shell-command-on-region embark--ignore-target)


### PR DESCRIPTION
The `align-regexp` action did not prompt the user for a regular expression unless the `embark--ignore-target` hook was explicitly added.

Since the align-regexp action was added as a default to the region keymap, I assume this addition to the default target-injection-hooks makes sense.

Tested on `GNU Emacs 29.0.50 (build 1, aarch64-apple-darwin21.1.0, NS appkit-2113.00 Version 12.0.1 (Build 21A559))
of 2021-12-07`