### PR TITLE
Prevent dired from reusing embark-export-dired buffer

### DIFF
--- a/embark.el
+++ b/embark.el
@@ -3223,6 +3223,7 @@ PRED is a predicate function used to filter the items."
                      (mapcar (lambda (file) (string-remove-prefix dir file))
                              files)))))
     (with-current-buffer buf
+      (setq-local dired-directory nil)
       (rename-buffer (format "*Embark Export Dired %s*" default-directory)))
     (pop-to-buffer buf)))
 


### PR DESCRIPTION
Assume you narrow files inside directory ~/.emacs.d, and export the
completion candidates to embark, embark will create a dired
buffer(using dired-noselect) to display them.

The problem is, dired will reuse buffer whenever possible.
If you go to ~/.emacs.d again later, the narrowed buffer will show up,
instead of the full content under ~/.emacs.d...

A quick work around is to unset dired-directory, then
dired-find-buffer-nocreate won't reuse this buffer.