### PR TITLE
Find targets in imaged-dired

### DIFF
--- a/embark.el
+++ b/embark.el
@@ -650,8 +650,13 @@ This function is meant to be added to `minibuffer-setup-hook'."
 
 (defun embark-target-file-at-point ()
   "Target file at point.
-This function mostly relies on `ffap-file-at-point', with one exception:
-In `dired-mode', it uses `dired-get-filename' instead."
+This function mostly relies on `ffap-file-at-point', with the
+following exceptions:
+
+- In `dired-mode', it uses `dired-get-filename' instead.
+
+- In `imaged-dired-thumbnail-mode', it uses
+  `image-dired-original-file-name' instead."
   (if-let (file (or (and (derived-mode-p 'dired-mode)
                          (dired-get-filename t 'no-error-if-not-filep))
                     (and (derived-mode-p 'image-dired-thumbnail-mode)

--- a/embark.el
+++ b/embark.el
@@ -652,8 +652,10 @@ This function is meant to be added to `minibuffer-setup-hook'."
   "Target file at point.
 This function mostly relies on `ffap-file-at-point', with one exception:
 In `dired-mode', it uses `dired-get-filename' instead."
-  (if-let (file (and (derived-mode-p 'dired-mode)
-                     (dired-get-filename t 'no-error-if-not-filep)))
+  (if-let (file (or (and (derived-mode-p 'dired-mode)
+                         (dired-get-filename t 'no-error-if-not-filep))
+                    (and (derived-mode-p 'image-dired-thumbnail-mode)
+                         (image-dired-original-file-name))))
       (save-excursion
         (end-of-line)
         `(file ,(abbreviate-file-name (expand-file-name file))


### PR DESCRIPTION
Hello,

I noticed that embark didn't act on files in `image-dired`. In this PR, I have extended the file target finder to make it behave as in `dired-mode`. Please feel free to moderate these commits.