### PR TITLE
Alternative prompts for any function

### DIFF
--- a/embark.el
+++ b/embark.el
@@ -3952,6 +3952,7 @@ library, which have an obvious notion of associated directory."
   ("B" embark-become)
   ("A" embark-act-all)
   ("C-s" embark-isearch)
+  ("C-r" embark-alternative-input)
   ("SPC" mark)
   ("DEL" delete-region))
 

--- a/embark.el
+++ b/embark.el
@@ -2405,6 +2405,17 @@ the command that opened the minibuffer in the first place."
          ,(if parent `(make-composed-keymap ,map ,parent) map))
        ,doc)))
 
+;;; Alternative input
+
+(defcustom embark-alternative-input-alist nil
+  "Alist of functions and keymaps for alternative input.
+Each car is the symbol of a function. Each cdr is the symbol of a
+keymap, containing bindings to functions which must each return a
+string. See also `embark-alternative-input'."
+  :group 'embark
+  :type '(alist :key-type (symbol :tag "Target type")
+                :value-type (variable :tag "Keymap")))
+
 ;;; Embark collect
 
 (defgroup embark-collect nil


### PR DESCRIPTION
Fix #528

I'm really proud of this.

## Motivation
From the above issue:

> The basic idea is that I could call some embark action during any call to read-file-name, be presented with a list of possible alternatives (some of which I might have defined myself), like with embark-become, select one, type something, hit enter, have the function I chose return something from that input, and have that return value returned to whatever function initially called read-file-name.
> 
> That's the abstract version. Here's a motivating use-case. I'm a student, and I often need to send academic papers to other people at my university. As a good amateur archivist, I name all my pdfs with the key of the relevant bib entry in my bib file. This makes it very easy for ebib and citar to play nicely with my pdf library, which is great. But if I want to attach a file to an email, I have to open ebib, find the record, copy its key, switch back to the email, attach a file (which calls read-file-name), then navigate to my pdf dir and yank the key into the minibuffer. It would be very easy to hack together a function from the ebib or citar codebases which reads a paper name and returns the filepath to it, but I wouldn't be able to use this directly in my email composition -- thus the idea of integrating with embark using functionality similar to become.


## Functionality
What I've written is actually more generic -- a general way to use alternative prompts in functions which prompt for input in the minibuffer. Think of it like embark-become, but for the current prompt, *not* the whole command. 

The user experience is heavily inspired by `embark-become`:
- When in a minibuffer prompt, run `embark-alternative-input` (from an embark prompt or otherwise)
- If any of the functions in the current backtrace appear in `embark-alternative-input-alist`, then present the keymap of the first one which does. This can be used to select an function. Functions can also be run from <kbd>M-x</kbd>. (see shortcomings below)
- This function should return a string, which is then inserted into the minibuffer.

This string can have text properties which determine whether we then run `exit-minibuffer`. This is because the idea of this feature is for users to write their own functions which are useful for their own workflows, so I wanted it to be possible to write powerful DWIM commands (hence the exit/don't exit customisability), while also leaving it fairly easy for users who don't know much elisp to write *something* (hence using strings rather than a more complex data structure as return values). The default is to not exit, and there is a prefix argument on the command which changes this.

## Working example

This should run on any recent Emacs, and demonstrates using bookmarks as input, as well as useful DWIM functionality with the text properties.

``` emacs-lisp
(defun my/filename-from-bookmark ()
  (interactive)
  (let ((file
	 (bookmark-get-filename
	  (bookmark-completing-read "Filename for bookmark"
				    bookmark-current-bookmark))))
    ;; Accept if a file, allow edit if a directory
    (propertize file 'embark-replace-input-accept (not (file-directory-p file)))))
	  
(embark-define-keymap my/embark-alternative-input-read-file-name-keymap
  "Keymap for `read-file-name' alternative inputs.
Functions must return a string (in particular,they should return
\"\", rather than nil, as a 'null' return value). See also
`embark-alternative-input'."
  :parent nil
  ("m" '("Filename from bookmark" . my/filename-from-bookmark)))
	
(setq
 embark-alternative-input-alist
 '((read-file-name . my/embark-alternative-input-read-file-name-keymap)))
```

## Shortcomings
Some things I think would be cool, but I can't make work:

I've bound `embark-alternative-input` to <kbd>C-r</kbd> in `embark-general-map`. Is this an alright key?

Target cycling would be great. Say I have different alternative input keymaps set up for `org-msg-attach` and `read-file-name`. `org-msg-attach` calls `read-file-name`, so when I call `embark-alternative-input`, `read-file-name` will be the first function it recognises as relevant in the backtrace (the "target"). This is fine, but there is currently no way to say "no, I want the *next* relevant function back in the trace" (which in this case would be `org-msg-attach`). I've had a brief look at the code for `embark-cycle` and found it a bit impenetrable. Would be happy to have a go at implementing this if someone gave me some pointers though.

I *think* error and exit handling (signalling "Cancelled" at the right time etc.) is correct, but it would be good if someone else could check this especially.