### PR TITLE
Add a .dir-locals.el file to avoid white space issues

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,6 @@
+;;; Directory Local Variables
+;;; For more information see (info "(emacs) Directory Variables")
+
+((emacs-lisp-mode
+  (show-trailing-whitespace . t)
+  (indent-tabs-mode . nil)))


### PR DESCRIPTION
When contributing #534, I had first pushed a commit that used tabs, even though the entire file is indented using spaces.  I'd suggest adding a file like the one in this patch to avoid issues like these in the future.