### PR TITLE
Check `category` is not nil in `embark-target-top-minibuffer-completion`

### DIFF
--- a/embark.el
+++ b/embark.el
@@ -856,7 +856,8 @@ their own target finder.  See for example
                              (substring contents
                                         0 (or (cdr (last completions)) 0))
                              (car completions)))))))
-      (cons category (or (car (member top candidates)) top)))))
+      (when category
+        (cons category (or (car (member top candidates)) top))))))
 
 (defun embark-target-collect-candidate ()
   "Target the collect candidate at point."


### PR DESCRIPTION
I encounter a bug using `embark-act` from the minibuffer.  I do `eval-expression`, type `(cons` and then invoke `embark-act`.  For me, this causes `Act on nil` to appear at the top of the `*Embark Actions*` buffer.  With this change, the `*Embark Actions*` buffer shows `Act on function` and allows me to use actions for function as I’d expect.
