### PR TITLE
Add declare-function to silence compiler warning

### DIFF
--- a/embark.el
+++ b/embark.el
@@ -647,6 +647,7 @@ This function is meant to be added to `minibuffer-setup-hook'."
       `(region ,(buffer-substring start end) . (,start . ,end)))))
 
 (autoload 'dired-get-filename "dired")
+(declare-function image-dired-original-file-name "image-dired")
 
 (defun embark-target-file-at-point ()
   "Target file at point.


### PR DESCRIPTION
Hotfix for #529 which has just been merged. Sorry for this.