### PR TITLE
Add a warning in case embark-consult cannot be loaded

### DIFF
--- a/README.org
+++ b/README.org
@@ -189,10 +189,10 @@ sets:
   package menu mode.
 
   If you use the grepping commands from the [[https://github.com/minad/consult/][Consult]] package,
-  =consult-grep=, =consult-git-grep= or =consult-ripgrep=, then you'll
-  probably want to install and load the =embark-consult= package, which
-  adds support for exporting a list of grep results to an honest
-  grep-mode buffer, on which you can even use [[https://github.com/mhayashi1120/Emacs-wgrep][wgrep]] if you wish.
+  =consult-grep=, =consult-git-grep= or =consult-ripgrep=, then you should
+  install the =embark-consult= package, which adds support for exporting a
+  list of grep results to an honest grep-mode buffer, on which you can
+  even use [[https://github.com/mhayashi1120/Emacs-wgrep][wgrep]] if you wish.
 
 When in doubt choosing between exporting and collecting, a good rule
 of thumb is to always prefer =embark-export= since when an exporter to a

--- a/embark-consult.el
+++ b/embark-consult.el
@@ -24,12 +24,8 @@
 
 ;;; Commentary:
 
-;; This package provides integration between Embark and Consult. To
-;; use it, arrange for it to be loaded once both of those are loaded:
-
-;; (with-eval-after-load 'consult
-;;   (with-eval-after-load 'embark
-;;     (require 'embark-consult)))
+;; This package provides integration between Embark and Consult. The package
+;; will be loaded automatically by Embark.
 
 ;; Some of the functionality here was previously contained in Embark
 ;; itself:

--- a/embark.el
+++ b/embark.el
@@ -3259,6 +3259,14 @@ PRED is a predicate function used to filter the items."
 
 ;;; Integration with external completion UIs
 
+;; consult
+
+(with-eval-after-load 'consult
+  (unless (require 'embark-consult nil 'noerror)
+    (warn "The package embark-consult should be installed if you use both Embark and Consult")))
+
+;; marginalia
+
 ;; Ensure that the Marginalia cache is reset, such that
 ;; `embark-toggle-variable-value' updates the display (See #540).
 (with-eval-after-load 'marginalia

--- a/embark.el
+++ b/embark.el
@@ -316,17 +316,6 @@ indicate that for files at the prompt of the `delete-file' command,
                                         (symbol :tag "Command")))
                 :value-type (function :tag "Default action")))
 
-(make-obsolete-variable
-   'embark-allow-edit-actions
-   "To allow editing for an action add `embark--allow-edit' to the
-entry of `embark-target-injection-hooks' whose key is the action."
-   "0.14")
-
-(define-obsolete-variable-alias
-  'embark-setup-action-hooks
-  'embark-target-injection-hooks
-  "0.14")
-
 (defcustom embark-target-injection-hooks
   '((async-shell-command embark--allow-edit embark--shell-prep)
     (shell-command embark--allow-edit embark--shell-prep)
@@ -2433,12 +2422,6 @@ a list whose first element is a symbol indicating the type of
 candidates and whose `cdr' is the list of candidates, each of
 which should be a string."
   :type 'hook)
-
-(make-obsolete-variable
-   'embark-collect-initial-view-alist
-   "Support for different collect views has been removed.
-The zebra mode can be configured per completion type via `embark-collect-zebra-types'."
-   "0.16")
 
 (defcustom embark-collect-zebra-types
   '(kill-ring)


### PR DESCRIPTION
A missing embark-consult package seems to be a common issue. Warn about it.