### PR TITLE
embark-org: transform attachment link to org-file-link

### DIFF
--- a/embark-org.el
+++ b/embark-org.el
@@ -247,6 +247,12 @@
         (cons 'org-file-link
               (replace-regexp-in-string
                "::.*" "" (string-remove-prefix "file:" target))))
+       ((string-prefix-p "attachment:" target)
+        (cons 'org-file-link
+              (expand-file-name
+               (replace-regexp-in-string
+                "::.*" "" (string-remove-prefix "attachment:" target))
+               (org-attach-dir))))
        ((string-match-p "^[./]" target)
         (cons 'org-file-link (abbreviate-file-name (expand-file-name target))))
        ((string-prefix-p "elisp:(" target)


### PR DESCRIPTION
Hi, attachment links are basically the same as file links, so it would be convenient to support attachment links in `embark-org'.

> ‘attachment’
>      Same as file links but for files and folders attached to the
>      current node (see *note Attachments::).  Attachment links are
>      intended to behave exactly as file links but for files relative to
>      the attachment directory.

I've signed the FSF copyright assignment.