### PR TITLE
Auto load Org integration

### DIFF
--- a/embark-org.el
+++ b/embark-org.el
@@ -31,6 +31,7 @@
 
 (require 'embark)
 (require 'org)
+(require 'org-element)
 
 ;;; Basic target finder for Org
 
@@ -98,8 +99,6 @@
     ;; verse-block
     )
   "Supported Org object and element types.")
-
-(declare-function org-element-property "org-element" (property element))
 
 (defun embark-org-target-element-context ()
   "Target the smallest Org element or object around point."
@@ -289,10 +288,8 @@ what part or in what format the link is copied."
 (embark-org-define-link-copier description description "'s description")
 (embark-org-define-link-copier target target "'s target")
 
-(declare-function embark-org-copy-link-inner-target "embark-org")
-(fset 'embark-org-copy-link-inner-target 'kill-new)
-(put 'embark-org-copy-link-inner-target 'function-documentation
-      "Copy 'inner part' of the Org link at point's target.
+(defalias 'embark-org-copy-link-inner-target #'kill-new
+  "Copy 'inner part' of the Org link at point's target.
 For mailto and elisp links, the inner part is the portion of the
 target after 'mailto:' or 'elisp:'.
 

--- a/embark.el
+++ b/embark.el
@@ -4299,4 +4299,7 @@ library, which have an obvious notion of associated directory."
   (unless (require 'embark-consult nil 'noerror)
     (warn "The package embark-consult should be installed if you use both Embark and Consult")))
 
+(with-eval-after-load 'org
+  (require 'embark-org))
+
 ;;; embark.el ends here


### PR DESCRIPTION
I propose to make embark-org available automatically. The situation is the same with embark-consult. This way we make sure that the actions are available automatically.

We should probably wait for https://github.com/melpa/melpa/pull/8294, such that we don't trigger errors.