### PR TITLE
embark-export-apropos: Ensure that symbol order is preserved

### DIFF
--- a/embark.el
+++ b/embark.el
@@ -3165,9 +3165,11 @@ PRED is a predicate function used to filter the items."
   "Create apropos buffer listing SYMBOLS."
   (embark--export-rename "*Apropos*" "Apropos"
     (apropos-parse-pattern "") ;; Initialize apropos pattern
-    (apropos-symbols-internal
-     (delq nil (mapcar #'intern-soft symbols))
-     (bound-and-true-p apropos-do-all))))
+    ;; HACK: Ensure that order of exported symbols is kept.
+    (cl-letf (((symbol-function #'sort) (lambda (list _pred) (nreverse list))))
+      (apropos-symbols-internal
+       (delq nil (mapcar #'intern-soft symbols))
+       (bound-and-true-p apropos-do-all)))))
 
 (defun embark-export-customize-face (faces)
   "Create a customization buffer listing FACES."


### PR DESCRIPTION
It would be great if we can improve the apropos export a little bit. I would like to deprecate the `consult-apropos` command which has always been somewhat ill-defined. See https://github.com/minad/consult/commit/eacc143a4439a394b5da2124e2550816c66c6d41.