### PR TITLE
Add match highlight and count to grep export

### DIFF
--- a/embark-consult.el
+++ b/embark-consult.el
@@ -155,6 +155,8 @@ This function is meant to be added to `embark-collect-mode-hook'."
 
 ;;; Support for consult-grep
 
+(defvar grep-mode-line-matches)
+(defvar grep-num-matches-found)
 (defvar wgrep-header/footer-parser)
 (declare-function wgrep-setup "ext:wgrep")
 
@@ -165,12 +167,25 @@ This function is meant to be added to `embark-collect-mode-hook'."
 
 (defun embark-consult-export-grep (lines)
   "Create a grep mode buffer listing LINES."
-  (let ((buf (generate-new-buffer "*Embark Export Grep*")))
+  (let ((buf (generate-new-buffer "*Embark Export Grep*"))
+        (count 0)
+        prop)
     (with-current-buffer buf
       (insert (propertize "Exported grep results:\n\n" 'wgrep-header t))
       (dolist (line lines) (insert line "\n"))
       (goto-char (point-min))
+      (while (setq prop (text-property-search-forward
+                         'face 'consult-highlight-match t))
+        (cl-incf count)
+        (put-text-property (prop-match-beginning prop)
+                           (prop-match-end prop)
+                           'font-lock-face
+                           'match))
+      (goto-char (point-min))
       (grep-mode)
+      (when (> count 0)
+        (setq-local grep-num-matches-found count
+                    mode-line-process grep-mode-line-matches))
       ;; Make this buffer current for next/previous-error
       (setq next-error-last-buffer buf)
       ;; Set up keymap before possible wgrep-setup, so that wgrep


### PR DESCRIPTION
What do you think? The match counting part is a bit problematic (and we could get rid of it) because:
 1. Consult currently only highlights the first match in a line, so the counting, effectively, is of matched lines and not actual matches as in `rgrep` etc.
 2. Even if all matches were highlighted, we wouldn't be able to count adjacent matches correctly (say "abc" matches "abcabc" twice), because we are actually counting the number of contiguous regions of text that match.