### PR TITLE
Revert "Remove embark-open-externally to avoid duplication with consult"

### DIFF
--- a/embark-consult.el
+++ b/embark-consult.el
@@ -275,8 +275,6 @@ This function is meant to be added to `embark-collect-mode-hook'."
 
 ;;; Bindings for consult commands in embark keymaps
 
-(define-key embark-file-map "x" #'consult-file-externally)
-
 (define-key embark-become-file+buffer-map "Cb" #'consult-buffer)
 (define-key embark-become-file+buffer-map "C4b" #'consult-buffer-other-window)
 

--- a/embark.el
+++ b/embark.el
@@ -3597,6 +3597,19 @@ with command output.  For replacement behaviour see
                              command
                              (and replace (current-buffer)))))
 
+(defun embark-open-externally (file)
+  "Open FILE using system's default application."
+  (interactive "fOpen: ")
+  (if (and (eq system-type 'windows-nt)
+           (fboundp 'w32-shell-execute))
+      (w32-shell-execute "open" file)
+    (call-process (pcase system-type
+                    ('darwin "open")
+                    ('cygwin "cygstart")
+                    (_ "xdg-open"))
+                  nil 0 nil
+                  (expand-file-name file))))
+
 (defun embark-bury-buffer (buf)
   "Bury buffer BUF."
   (interactive "bBuffer: ")
@@ -4020,6 +4033,7 @@ library, which have an obvious notion of associated directory."
   ("\\" embark-recentf-remove)
   ("I" embark-insert-relative-path)
   ("W" embark-save-relative-path)
+  ("x" embark-open-externally)
   ("e" eww-open-file)
   ("l" load-file)
   ("b" byte-compile-file)


### PR DESCRIPTION
This reverts commit 470f64c864bf7437ffd610607d8fdc05ec4c1257.

Fix #572