### PR TITLE
Switch to the new key convention

### DIFF
--- a/embark.el
+++ b/embark.el
@@ -121,7 +121,11 @@
 
 (defgroup embark nil
   "Emacs Mini-Buffer Actions Rooted in Keymaps."
-  :group 'minibuffer)
+  :link '(info-link :tag "Info Manual" "(embark)")
+  :link '(url-link :tag "Homepage" "https://github.com/oantolin/embark")
+  :link '(emacs-library-link :tag "Library Source" "embark.el")
+  :group 'minibuffer
+  :prefix "embark-")
 
 (defcustom embark-keymap-alist
   '((file embark-file-map)

--- a/embark.el
+++ b/embark.el
@@ -2426,11 +2426,10 @@ point."
          (setq this-command command)
          (command-execute command))))))
 
-(make-obsolete
- 'embark-define-keymap
- "Use standard methods for defining keymaps, such as `defvar-keymap'.
-Remember to make `embark-general-map' the parent if appropriate."
- "0.20")
+(defmacro embark-define-keymap (&rest _)
+  (error "`embark-define-keymap' has been deprecated in Embark 0.21.
+Use standard methods for defining keymaps, such as `defvar-keymap'.
+Remember to make `embark-general-map' the parent if appropriate"))
 
 ;;; Embark collect
 


### PR DESCRIPTION
This change affects:

- embark-help-key
- embark-cycle-key
- embark-keymap-prompter-key