### PR TITLE
Finder for symbols in the help buffer

### DIFF
--- a/embark.el
+++ b/embark.el
@@ -179,7 +179,8 @@ or a list of such symbols."
     embark-target-sentence-at-point
     embark-target-paragraph-at-point
     embark-target-defun-at-point
-    embark-target-prog-heading-at-point)
+    embark-target-prog-heading-at-point
+    embark-target-help-symbol)
   "List of functions to determine the target in current context.
 Each function should take no arguments and return either:
 

--- a/embark.el
+++ b/embark.el
@@ -951,6 +951,32 @@ their own target finder.  See for example
                raw)
             ,beg . ,end))))))
 
+(defun embark-target-help-symbol ()
+  "Return the subject of the current help buffer.
+
+Guess symbol's heuristically. If `help-mode--current-data'
+has a :type property then follow that. If not return 'function if
+if the symbol passes `functionp', or 'face if it passes `facep'
+or 'symbol as a default."
+  (when help-mode--current-data
+    (let* ((sym (plist-get help-mode--current-data :symbol))
+           (type
+            ;; This is not perfect but covers lots of cases
+            (cond ((alist-get
+                    (plist-get help-mode--current-data :type)
+                    '((defvar . variable)
+                      (defface . face))))
+                  ((functionp sym) 'function)
+                  ((facep sym) 'face)
+                  'symbol))
+	   (name (symbol-name sym))
+	   beg end)
+      (save-excursion
+	(goto-char 0)
+	(setq end (search-forward name))
+	(setq beg (search-backward name)))
+      `(,type ,name ,beg . ,end))))
+
 (defun embark--cycle-key ()
   "Return the key to use for `embark-cycle'."
   (if embark-cycle-key


### PR DESCRIPTION
I wrote this today as a convenience for myself, and realised others might also use it. It's a target finder which locates the symbol a help buffer describes, and makes heuristic guesses about what type of thing it is. It isn't perfect, but it might be useful for someone.