### PR TITLE
Add embark-eldoc-function (Fix #599)

### DIFF
--- a/embark.el
+++ b/embark.el
@@ -992,6 +992,15 @@ If CYCLE is non-nil bind `embark-cycle'."
       (concat (car (split-string target "\n" 'omit-nulls "\\s-*")) "…")
     target))
 
+(defun embark-eldoc-function (report &rest _)
+  "Eldoc function reporting the target at point via the REPORT callback.
+This function can be added to `eldoc-documentation-functions'."
+  (when-let ((target (car (embark--targets))))
+    (funcall report
+             (format "Embark on %s ‘%s’"
+                     (plist-get target :type)
+                     (embark--truncate-target (plist-get target :target))))))
+
 (defun embark--format-targets (target shadowed-targets rep)
   "Return a formatted string indicating the TARGET of an action.
 
@@ -1022,7 +1031,7 @@ a repeating sequence of actions."
               (plist-get target :multi)
               (plist-get target :type)))
      (t (format
-         "%s on %s%s '%s'"
+         "%s on %s%s ‘%s’"
          act
          (plist-get target :type)
          (if shadowed-targets
@@ -2427,6 +2436,7 @@ point."
          (command-execute command))))))
 
 (defmacro embark-define-keymap (&rest _)
+  "Obsolete macro, use `defvar-keymap' instead."
   (error "`embark-define-keymap' has been deprecated in Embark 0.21.
 Use standard methods for defining keymaps, such as `defvar-keymap'.
 Remember to make `embark-general-map' the parent if appropriate"))

--- a/embark.el
+++ b/embark.el
@@ -992,14 +992,27 @@ If CYCLE is non-nil bind `embark-cycle'."
       (concat (car (split-string target "\n" 'omit-nulls "\\s-*")) "…")
     target))
 
-(defun embark-eldoc-function (report &rest _)
-  "Eldoc function reporting the target at point via the REPORT callback.
-This function can be added to `eldoc-documentation-functions'."
+(defun embark-eldoc-first-target (report &rest _)
+  "Eldoc function reporting the first Embark target at point.
+This function uses the eldoc REPORT callback and is meant to be
+added to `eldoc-documentation-functions'."
   (when-let ((target (car (embark--targets))))
     (funcall report
              (format "Embark on %s ‘%s’"
                      (plist-get target :type)
                      (embark--truncate-target (plist-get target :target))))))
+
+(defun embark-eldoc-target-types (report &rest _)
+  "Eldoc function reporting the types of all Embark targets at point.
+This function uses the eldoc REPORT callback and is meant to be
+added to `eldoc-documentation-functions'."
+  (when-let ((targets (embark--targets)))
+    (funcall report
+             (format "Embark target types: %s"
+                     (mapconcat
+                      (lambda (target) (symbol-name (plist-get target :type)))
+                      targets
+                      ", ")))))
 
 (defun embark--format-targets (target shadowed-targets rep)
   "Return a formatted string indicating the TARGET of an action.


### PR DESCRIPTION
I think it is worth adding this. It is such a cheap addition given that Eldoc handles everything, timers etc. Needs this configuration:

~~~ elisp
(add-hook 'eldoc-documentation-functions #'embark-eldoc-function)
(setq eldoc-documentation-strategy #'eldoc-documentation-compose-eagerly)
~~~

I haven't added documentation to the README.