### PR TITLE
Drop Selectrum support

### DIFF
--- a/README.org
+++ b/README.org
@@ -223,7 +223,7 @@ Finally, there is also an =embark-live= variant of the =embark-collect=
 command which automatically updates the collection after each change
 in the source buffer. Users of a completion UI that automatically
 updates and displays the candidate list (such as Vertico, Icomplete,
-Selectrum, Fido-mode, or MCT) will probably not want to use
+Fido-mode, or MCT) will probably not want to use
 =embark-live= from the minibuffer as they will then have two live
 updating displays of the completion candidates!
 
@@ -358,7 +358,7 @@ Embark needs to know what your minibuffer completion system considers
 to be the list of candidates and which one is the current candidate.
 Embark works out of the box if you use Emacs's default tab completion,
 the built-in =icomplete-mode= or =fido-mode=, or the third-party packages
-[[https://github.com/minad/vertico][Vertico]], [[https://github.com/raxod502/selectrum/][Selectrum]] or [[https://github.com/abo-abo/swiper][Ivy]].
+[[https://github.com/minad/vertico][Vertico]] or [[https://github.com/abo-abo/swiper][Ivy]].
 
 If you are a [[https://emacs-helm.github.io/helm/][Helm]] or [[https://github.com/abo-abo/swiper][Ivy]] user you are unlikely to want Embark since
 those packages include comprehensive functionality for acting on

--- a/embark.el
+++ b/embark.el
@@ -893,7 +893,7 @@ This target finder is meant for the default completion UI and
 completion UI highly compatible with it, like Icomplete.
 Many completion UIs can still work with Embark but will need
 their own target finder.  See for example
-`embark--vertico-selected' or `embark--selectrum-selected'."
+`embark--vertico-selected'."
   (when (and (minibufferp) minibuffer-completion-table)
     (pcase-let* ((`(,category . ,candidates) (embark-minibuffer-candidates))
                  (contents (minibuffer-contents))
@@ -3337,52 +3337,6 @@ Return the category metadatum as the type of the candidates."
   (add-hook 'embark-indicators #'embark--vertico-indicator)
   (add-hook 'embark-target-finders #'embark--vertico-selected)
   (add-hook 'embark-candidate-collectors #'embark--vertico-candidates))
-
-;; selectrum
-
-(declare-function selectrum--get-meta "ext:selectrum")
-(declare-function selectrum-get-current-candidate "ext:selectrum")
-(declare-function selectrum-get-current-candidates "ext:selectrum")
-(declare-function selectrum-exhibit "ext:selectrum")
-(defvar selectrum-is-active)
-(defvar selectrum--previous-input-string)
-
-(defun embark--selectrum-selected ()
-  "Target the currently selected item in Selectrum.
-Return the category metadatum as the type of the target."
-  (when selectrum-is-active
-    ;; Force candidate computation, if candidates are not yet available.
-    (unless selectrum--previous-input-string
-      (selectrum-exhibit))
-    (cons (selectrum--get-meta 'category)
-          (selectrum-get-current-candidate))))
-
-(defun embark--selectrum-candidates ()
-  "Collect the current Selectrum candidates.
-Return the category metadatum as the type of the candidates."
-  (when selectrum-is-active
-    ;; Force candidate computation, if candidates are not yet available.
-    (unless selectrum--previous-input-string
-      (selectrum-exhibit))
-    (cons (selectrum--get-meta 'category)
-          (selectrum-get-current-candidates
-           ;; Pass relative file names for dired.
-           minibuffer-completing-file-name))))
-
-(defun embark--selectrum-indicator ()
-  "Embark indicator highlighting the current Selectrum candidate."
-  (let ((fr face-remapping-alist))
-    (lambda (&optional keymap _targets _prefix)
-      (when selectrum-is-active
-        (setq-local face-remapping-alist
-                    (if keymap
-                        (cons '(selectrum-current-candidate . embark-target) fr)
-                      fr))))))
-
-(with-eval-after-load 'selectrum
-  (add-hook 'embark-indicators #'embark--selectrum-indicator)
-  (add-hook 'embark-target-finders #'embark--selectrum-selected)
-  (add-hook 'embark-candidate-collectors #'embark--selectrum-candidates))
 
 ;; ivy
 

--- a/embark.texi
+++ b/embark.texi
@@ -332,7 +332,7 @@ Finally, there is also an @samp{embark-live} variant of the @samp{embark-collect
 command which automatically updates the collection after each change
 in the source buffer. Users of a completion UI that automatically
 updates and displays the candidate list (such as Vertico, Icomplete,
-Selectrum, Fido-mode, or MCT) will probably not want to use
+Fido-mode, or MCT) will probably not want to use
 @samp{embark-live} from the minibuffer as they will then have two live
 updating displays of the completion candidates!
 
@@ -474,7 +474,7 @@ Embark needs to know what your minibuffer completion system considers
 to be the list of candidates and which one is the current candidate.
 Embark works out of the box if you use Emacs's default tab completion,
 the built-in @samp{icomplete-mode} or @samp{fido-mode}, or the third-party packages
-@uref{https://github.com/minad/vertico, Vertico}, @uref{https://github.com/raxod502/selectrum/, Selectrum} or @uref{https://github.com/abo-abo/swiper, Ivy}.
+@uref{https://github.com/minad/vertico, Vertico} or @uref{https://github.com/abo-abo/swiper, Ivy}.
 
 If you are a @uref{https://emacs-helm.github.io/helm/, Helm} or @uref{https://github.com/abo-abo/swiper, Ivy} user you are unlikely to want Embark since
 those packages include comprehensive functionality for acting on


### PR DESCRIPTION
Selectrum has been deprecated in favor of Vertico. Selectrum support has already been dropped from Marginalia and Consult.

We could keep support for longer, since the additional code doesn't hurt. But I think it is better to nudge the community to move over to completion UIs which are more compliant with the Emacs completion mechanism (Vertico, Icomplete, etc.). 