### PR TITLE
Disable Embark Eldoc in minibuffer

### DIFF
--- a/README.org
+++ b/README.org
@@ -306,6 +306,10 @@ starting configuration:
     ;; Optionally replace the key help with a completing-read interface
     (setq prefix-help-command #'embark-prefix-help-command)
 
+    ;; Show the Embark target at point via Eldoc
+    (setq eldoc-documentation-strategy #'eldoc-documentation-compose-eagerly)
+    (add-hook 'eldoc-documentation-functions #'embark-eldoc-first-target)
+
     :config
 
     ;; Hide the mode line of the Embark live/completions buffers

--- a/README.org
+++ b/README.org
@@ -306,9 +306,10 @@ starting configuration:
     ;; Optionally replace the key help with a completing-read interface
     (setq prefix-help-command #'embark-prefix-help-command)
 
-    ;; Show the Embark target at point via Eldoc
-    (setq eldoc-documentation-strategy #'eldoc-documentation-compose-eagerly)
+    ;; Show the Embark target at point via Eldoc.  You may adjust the Eldoc
+    ;; strategy, if you want to see the documentation from multiple providers.
     (add-hook 'eldoc-documentation-functions #'embark-eldoc-first-target)
+    ;; (setq eldoc-documentation-strategy #'eldoc-documentation-compose-eagerly)
 
     :config
 

--- a/embark.el
+++ b/embark.el
@@ -1000,7 +1000,8 @@ If CYCLE is non-nil bind `embark-cycle'."
   "Eldoc function reporting the first Embark target at point.
 This function uses the eldoc REPORT callback and is meant to be
 added to `eldoc-documentation-functions'."
-  (when-let ((target (car (embark--targets))))
+  (when-let (((not (minibufferp)))
+             (target (car (embark--targets))))
     (funcall report
              (format "Embark on %s ‘%s’"
                      (plist-get target :type)
@@ -1011,7 +1012,8 @@ added to `eldoc-documentation-functions'."
   "Eldoc function reporting the types of all Embark targets at point.
 This function uses the eldoc REPORT callback and is meant to be
 added to `eldoc-documentation-functions'."
-  (when-let ((targets (embark--targets)))
+  (when-let (((not (minibufferp)))
+             (targets (embark--targets)))
     (funcall report
              (format "Embark target types: %s"
                      (mapconcat

--- a/embark.texi
+++ b/embark.texi
@@ -417,9 +417,10 @@ starting configuration:
   ;; Optionally replace the key help with a completing-read interface
   (setq prefix-help-command #'embark-prefix-help-command)
 
-  ;; Show the Embark target at point via Eldoc
-  (setq eldoc-documentation-strategy #'eldoc-documentation-compose-eagerly)
+  ;; Show the Embark target at point via Eldoc.  You may adjust the Eldoc
+  ;; strategy, if you want to see the documentation from multiple providers.
   (add-hook 'eldoc-documentation-functions #'embark-eldoc-first-target)
+  ;; (setq eldoc-documentation-strategy #'eldoc-documentation-compose-eagerly)
 
   :config
 

--- a/embark.texi
+++ b/embark.texi
@@ -417,6 +417,10 @@ starting configuration:
   ;; Optionally replace the key help with a completing-read interface
   (setq prefix-help-command #'embark-prefix-help-command)
 
+  ;; Show the Embark target at point via Eldoc
+  (setq eldoc-documentation-strategy #'eldoc-documentation-compose-eagerly)
+  (add-hook 'eldoc-documentation-functions #'embark-eldoc-first-target)
+
   :config
 
   ;; Hide the mode line of the Embark live/completions buffers


### PR DESCRIPTION
In the minibuffer the Embark target is obvious. The problem is that Eldoc abuses the modeline to display the Eldoc information at point, which is noisy and unnecessary in this case.

Follow-up of #600 and #605