### PR TITLE
Make `embark-export` abide to `display-buffer-alist`

### DIFF
--- a/embark.el
+++ b/embark.el
@@ -3118,17 +3118,17 @@ buffer."
                         (alist-get t embark-exporters-alist))))
       (if (eq exporter 'embark-collect)
           (embark-collect)
-        (let ((after embark-after-export-hook)
-              (cmd embark--command)
-              (name (embark--descriptive-buffer-name 'export))
-              (rerun (embark--rerun-function #'embark-export))
-              (buffer (save-excursion
-                        (funcall exporter candidates)
-                        (current-buffer))))
+        (let* ((after embark-after-export-hook)
+               (cmd embark--command)
+               (name (embark--descriptive-buffer-name 'export))
+               (rerun (embark--rerun-function #'embark-export))
+               (buffer (save-excursion
+                         (funcall exporter candidates)
+                         (rename-buffer name t)
+                         (current-buffer))))
           (embark--quit-and-run
            (lambda ()
              (pop-to-buffer buffer)
-             (rename-buffer name t)
              (setq embark--rerun-function rerun)
              (use-local-map
               (make-composed-keymap


### PR DESCRIPTION
This change makes it so that `buffer` is named before it is
`pop-to-buffer`'d to, so that the rules specified `display-buffer-alist`
can be matched by the Embark export buffer name patterns.

E.g., the following addition makes Embark export buffers show in a
side window.
```elisp
(add-to-list 'display-buffer-alist '("\\*Embark Export: .*"
                                     (display-buffer-in-side-window)))
```