### PR TITLE
Fix: Rename category embark-selected to embark-selected-overlay

### DIFF
--- a/embark.el
+++ b/embark.el
@@ -555,10 +555,10 @@ action."
 
 ;; high priority to override both bug reference and the lazy
 ;; isearch highlights in embark-isearch-highlight-indicator
-(put 'embark-target 'face 'embark-target)
-(put 'embark-target 'priority 1001)
-(put 'embark-selected 'face 'embark-selected)
-(put 'embark-selected 'priority 1001)
+(put 'embark-target-overlay 'face 'embark-target)
+(put 'embark-target-overlay 'priority 1001)
+(put 'embark-selected-overlay 'face 'embark-selected)
+(put 'embark-selected-overlay 'priority 1001)
 
 ;;; Stashing information for actions in buffer local variables
 
@@ -2378,7 +2378,7 @@ ARG is the prefix argument."
           (if overlay
               (move-overlay overlay (car bounds) (cdr bounds))
             (setq overlay (make-overlay (car bounds) (cdr bounds)))
-            (overlay-put overlay 'category 'embark-target))
+            (overlay-put overlay 'category 'embark-target-overlay))
           (overlay-put overlay 'window (selected-window)))))))
 
 (defun embark-isearch-highlight-indicator ()
@@ -3292,7 +3292,7 @@ If BOUNDS are given, also highlight the target when selecting it."
       (let ((target (copy-sequence orig-target)) overlay)
         (when bounds
           (setq overlay (make-overlay (car bounds) (cdr bounds)))
-          (overlay-put overlay 'category 'embark-selected))
+          (overlay-put overlay 'category 'embark-selected-overlay))
         (add-text-properties 0 (length orig-target)
                              `(multi-category ,(cons orig-type orig-target))
                              target)


### PR DESCRIPTION
Otherwise the face property added by `defface embark-selected` conflicts with the overlay category properties. This leads to very weird errors in the messages buffer like `Invalid face reference: 1234` and the overlays are not displayed properly.