### PR TITLE
Silence byte-compiler

### DIFF
--- a/embark-consult.el
+++ b/embark-consult.el
@@ -260,10 +260,12 @@ This function is meant to be added to `embark-collect-mode-hook'."
 
 ;;; Support for consult-find and consult-locate
 
-(setf (alist-get '(file . consult-find) embark-default-action-overrides)
+(setf (alist-get '(file . consult-find) embark-default-action-overrides
+                 nil nil #'equal)
       #'find-file)
 
-(setf (alist-get '(file . consult-locate) embark-default-action-overrides)
+(setf (alist-get '(file . consult-locate) embark-default-action-overrides
+                 nil nil #'equal)
       #'find-file)
 
 ;;; Support for consult-isearch-history


### PR DESCRIPTION
```
lib/embark/embark-consult.el:263:20: Warning: ‘assq’ called with literal list that may never match (arg 1)
lib/embark/embark-consult.el:266:20: Warning: ‘assq’ called with literal list that may never match (arg 1)
```