### PR TITLE
Fix projectless search of Consult async commands

### DIFF
--- a/embark-consult.el
+++ b/embark-consult.el
@@ -387,9 +387,10 @@ for any action that is a Consult async command."
 The values of TYPE which are considered to have an associated
 directory are: file, buffer, bookmark and library.  The REST of
 the arguments are also passed to RUN."
-  (when (embark--associated-directory target type)
-    (let (consult-project-function)
-      (apply run :target target :type type rest))))
+  (if (embark--associated-directory target type)
+      (let (consult-project-function)
+        (apply run :target target :type type rest))
+    (apply run :target target :type type rest)))
 
 (map-keymap
  (lambda (_key cmd)

--- a/embark.el
+++ b/embark.el
@@ -3996,15 +3996,19 @@ the REST of the arguments."
   "Return directory associated to TARGET of given TYPE.
 The supported values of TYPE are file, buffer, bookmark and
 library, which have an obvious notion of associated directory."
-  (pcase type
-    ('file
-     (file-name-directory target))
-    ('buffer
-     (buffer-local-value 'default-directory (get-buffer target)))
-    ('bookmark
-     (file-name-directory (bookmark-location target)))
-    ('library
-     (file-name-directory (locate-library target)))))
+  (setq target (pcase type
+                 ('file
+                  target)
+                 ('buffer
+                  (buffer-local-value 'default-directory (get-buffer target)))
+                 ('bookmark
+                  (bookmark-location target))
+                 ('library
+                  (locate-library target))))
+  (when target
+    (if (file-directory-p target)
+        (file-name-as-directory target)
+      (file-name-directory target))))
 
 (autoload 'bookmark-location "bookmark")
 (cl-defun embark--cd (&rest rest &key run target type &allow-other-keys)


### PR DESCRIPTION
Fixes two things:

1. Always call the action, even if associated directory is nil.
2. If target is a directory itself, use it as associated directory.