### PR TITLE
Change key for org-sort to not conflict with outline-move-subtree-up

### DIFF
--- a/embark-org.el
+++ b/embark-org.el
@@ -398,7 +398,7 @@ bound to i."
   "T" #'org-tree-to-indirect-buffer
   "<left>" #'org-do-promote
   "<right>" #'org-do-demote
-  "^" #'org-sort
+  "o" #'org-sort
   "r" #'org-refile
   "R" #'embark-org-refile-here
   "I" #'org-clock-in


### PR DESCRIPTION
embark-org binds `^` to `org-sort` which overrides the binding for `outline-move-subtree-up`. This means that, when invoking `embark-act` on an org-mode heading, it's easy to move a subtree down, but you can't move it back up.

This little PR binds `org-sort` to `~`, which doesn't seem to have any conflicts on org headings. No other motivation for picking the `~` key.

This certainly doesn't fit the bill of a significant contribution, but I *have* signed a copyright assignment to the FSF, so we're doubly-covered in that regard.