### PR TITLE
Avoid car'ing dired-directory

### DIFF
--- a/embark.el
+++ b/embark.el
@@ -3364,7 +3364,7 @@ PRED is a predicate function used to filter the items."
                                  files)))))
     (with-current-buffer buf
       ;; Unadvertise to prevent the new buffer from being reused.
-      (dired-unadvertise (car dired-directory))
+      (dired-unadvertise dired-directory)
       (rename-buffer (format "*Embark Export Dired %s*" default-directory)))
     (pop-to-buffer buf)))
 


### PR DESCRIPTION
Fixes #701.

```
GNU Emacs 29.2 (build 1, aarch64-apple-darwin23.2.0, NS appkit-2487.30 Version 14.2.1 (Build 23C71))
```