### PR TITLE
Add default action for consult-xref

### DIFF
--- a/README.org
+++ b/README.org
@@ -398,8 +398,8 @@ About the suggested key bindings for =embark-act= and =embark-dwim=:
   installations of) GNOME to input emojis, and Emacs doesn't even get
   a chance to respond to the binding. You can select a different key
   binding for =embark-act= or use =ibus-setup= to change the shortcut for
-  emoji insertion (Emacs 29 will likely use =C-x 8 e e=, in case you
-  want to set the same one system-wide).
+  emoji insertion (Emacs 29 uses =C-x 8 e e=, in case you want to set
+  the same one system-wide).
 - The suggested alternative of =M-.= for =embark-dwim= is bound by default
   to =xref-find-definitions=. That is a very useful command but
   overwriting it with =embark-dwim= is sensible since in Embark's

--- a/embark-consult.el
+++ b/embark-consult.el
@@ -282,8 +282,9 @@ category `consult-grep'."
 
 ;;; Support for consult-xref
 
-(declare-function xref--show-xref-buffer "ext:xref")
 (declare-function consult-xref "ext:consult-xref")
+(declare-function xref--show-xref-buffer "xref")
+(declare-function xref-pop-to-location "xref")
 (defvar xref-auto-jump-to-first-xref)
 (defvar consult-xref--fetcher)
 
@@ -323,6 +324,13 @@ category `consult-grep'."
 
 (setf (alist-get 'consult-xref embark-exporters-alist)
       #'embark-consult-export-xref)
+
+(defun embark-consult-xref (cand)
+  "Default action override for `consult-xref', open CAND xref location."
+  (xref-pop-to-location (get-text-property 0 'consult-xref cand)))
+
+(setf (alist-get 'consult-xref embark-default-action-overrides)
+      #'embark-consult-xref)
 
 ;;; Support for consult-find and consult-locate
 

--- a/embark-consult.el
+++ b/embark-consult.el
@@ -7,7 +7,7 @@
 ;; Keywords: convenience
 ;; Version: 1.0
 ;; Homepage: https://github.com/oantolin/embark
-;; Package-Requires: ((emacs "27.1") (compat "29.1.4.0") (embark "1.0") (consult "1.0"))
+;; Package-Requires: ((emacs "27.1") (compat "30") (embark "1.0") (consult "1.7"))
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by

--- a/embark.el
+++ b/embark.el
@@ -500,7 +500,7 @@ used for other types of action hooks, for more details see
                         (const :tag "Always" :always))
                 :value-type hook))
 
-(when (version-list-< (version-to-list emacs-version) '(29 1))
+(static-if (< emacs-major-version 29)
   ;; narrow to target for duration of action
   (setf (alist-get 'repunctuate-sentences embark-around-action-hooks)
         '(embark--narrow-to-target)))
@@ -3942,7 +3942,7 @@ argument), no quoting is used for strings."
                (eval (read (buffer-substring beg end)) lexical-binding)))
       (delete-region beg end))))
 
-(when (< emacs-major-version 29)
+(static-if (< emacs-major-version 29)
   (defun embark-elp-restore-package (prefix)
     "Remove instrumentation from functions with names starting with PREFIX."
     (interactive "SPrefix: ")
@@ -4001,7 +4001,7 @@ ALGORITHM is the hash algorithm symbol understood by `secure-hash'."
     (access-file dir "Download failed")
     (url-retrieve
      url #'eww-download-callback
-     (if (>= emacs-major-version 28) (list url dir) (list url)))))
+     (static-if (>= emacs-major-version 28) (list url dir) (list url)))))
 
 ;;; Setup and pre-action hooks
 

--- a/embark.el
+++ b/embark.el
@@ -7,7 +7,7 @@
 ;; Keywords: convenience
 ;; Version: 1.0
 ;; Homepage: https://github.com/oantolin/embark
-;; Package-Requires: ((emacs "27.1") (compat "29.1.4.0"))
+;; Package-Requires: ((emacs "27.1") (compat "30"))
 
 ;; This file is part of GNU Emacs.
 

--- a/embark.texi
+++ b/embark.texi
@@ -522,8 +522,8 @@ The suggested @samp{C-.} binding is used by default in (at least some
 installations of) GNOME to input emojis, and Emacs doesn't even get
 a chance to respond to the binding. You can select a different key
 binding for @samp{embark-act} or use @samp{ibus-setup} to change the shortcut for
-emoji insertion (Emacs 29 will likely use @samp{C-x 8 e e}, in case you
-want to set the same one system-wide).
+emoji insertion (Emacs 29 uses @samp{C-x 8 e e}, in case you want to set
+the same one system-wide).
 @item
 The suggested alternative of @samp{M-.} for @samp{embark-dwim} is bound by default
 to @samp{xref-find-definitions}. That is a very useful command but


### PR DESCRIPTION
I applied a small [simplification](https://github.com/minad/consult/commit/41d382c9da9a84ab5391ee906e24f7126d03bd53) to consult-xref, but now we need an explicit default action override. I believe it is also advantageous and more efficient to use this override here, since we don't have to rerun the search action.