### PR TITLE
Require Emacs 28.1

### DIFF
--- a/README.org
+++ b/README.org
@@ -797,7 +797,7 @@ similar situations where the easiest option is not available.
 
 *** New minibuffer target example - tab-bar tabs
 
-As an example, take the new [[https://www.gnu.org/software/emacs/manual/html_node/emacs/Tab-Bars.html][tab bars]] from Emacs 27. I'll explain how
+As an example let us take a look at the [[https://www.gnu.org/software/emacs/manual/html_node/emacs/Tab-Bars.html][tab bars]]. I'll explain how
 to configure Embark to offer tab-specific actions when you use the
 tab-bar-mode commands that mention tabs by name. The configuration
 explained here is now built-in to Embark (and Marginalia), but it's
@@ -983,14 +983,14 @@ documentation for =embark-target-finders= for details.)
   commands). It also allows you to write new custom actions in such a
   way that they are useful even without Embark.
 
-  Staring from version 28.1, Emacs has a variable
-  =y-or-n-p-use-read-key=, which when set to =t= causes =y-or-n-p= to use
-  =read-key= instead of =read-from-minibuffer=. Setting
-  =y-or-n-p-use-read-key= to =t= is recommended for Embark users because
-  it keeps Embark from attempting to insert the target at a =y-or-n-p=
-  prompt, which would almost never be sensible. Also consider this as
-  a warning to structure your own action commands so that if they use
-  =y-or-n-p=, they do so only after the prompting for the target.
+  Emacs has a variable =y-or-n-p-use-read-key=, which when set to =t=
+  causes =y-or-n-p= to use =read-key= instead of =read-from-minibuffer=.
+  Setting =y-or-n-p-use-read-key= to =t= is recommended for Embark users
+  because it keeps Embark from attempting to insert the target at a
+  =y-or-n-p= prompt, which would almost never be sensible. Also consider
+  this as a warning to structure your own action commands so that if
+  they use =y-or-n-p=, they do so only after the prompting for the
+  target.
 
   Here is a simple example illustrating the various ways of reading
   input from the user mentioned above. Bind the following commands to

--- a/embark-consult.el
+++ b/embark-consult.el
@@ -7,7 +7,7 @@
 ;; Keywords: convenience
 ;; Version: 1.1
 ;; Homepage: https://github.com/oantolin/embark
-;; Package-Requires: ((emacs "27.1") (compat "30") (embark "1.0") (consult "1.7"))
+;; Package-Requires: ((emacs "28.1") (compat "30") (embark "1.1") (consult "1.8"))
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by

--- a/embark.el
+++ b/embark.el
@@ -7,7 +7,7 @@
 ;; Keywords: convenience
 ;; Version: 1.1
 ;; Homepage: https://github.com/oantolin/embark
-;; Package-Requires: ((emacs "27.1") (compat "30"))
+;; Package-Requires: ((emacs "28.1") (compat "30"))
 
 ;; This file is part of GNU Emacs.
 
@@ -1967,9 +1967,7 @@ If called outside the minibuffer, simply apply FN to ARGS."
     (apply #'embark--run-after-command fn args)
     (embark--run-after-command #'set 'ring-bell-function ring-bell-function)
     (setq ring-bell-function #'ignore)
-    (if (fboundp 'minibuffer-quit-recursive-edit)
-        (minibuffer-quit-recursive-edit)
-      (abort-recursive-edit))))
+    (minibuffer-quit-recursive-edit)))
 
 (defun embark--run-action-hooks (hooks action target quit)
   "Run HOOKS for ACTION.
@@ -2138,7 +2136,6 @@ work on them."
             (symbol-name (lookup-minor-mode-from-indicator target))))))
 
 (declare-function project-current "project")
-(declare-function project-roots "project")
 (declare-function project-root "project")
 
 (defun embark--project-file-full-path (_type target)
@@ -2148,10 +2145,7 @@ work on them."
   ;; case yet, since there is no current project.
   (cons 'file
         (if-let ((project (project-current))
-                 (root (if (fboundp 'project-root)
-                           (project-root project)
-                         (with-no-warnings
-                           (car (project-roots project))))))
+                 (root (project-root project)))
             (expand-file-name target root)
           target)))
 
@@ -3666,11 +3660,6 @@ its own."
             (ins-string))
         (ins-string)))))
 
-;; For Emacs 28 dired-jump will be moved to dired.el, but it seems
-;; that since it already has an autoload in Emacs 28, this next
-;; autoload is ignored.
-(autoload 'dired-jump "dired-x" nil t)
-
 (defun embark-dired-jump (file &optional other-window)
   "Open Dired buffer in directory containing FILE and move to its line.
 When called with a prefix argument OTHER-WINDOW, open Dired in other window."
@@ -4008,9 +3997,7 @@ It assumes the URL was encoded in UTF-8."
   (let ((dir eww-download-directory))
     (when (functionp dir) (setq dir (funcall dir)))
     (access-file dir "Download failed")
-    (url-retrieve
-     url #'eww-download-callback
-     (static-if (>= emacs-major-version 28) (list url dir) (list url)))))
+    (url-retrieve url #'eww-download-callback (list url dir))))
 
 ;;; Setup and pre-action hooks
 
@@ -4216,10 +4203,6 @@ This simply calls RUN with the REST of its arguments inside
 
 (fset 'embark-sort-map embark-sort-map)
 
-;; these will have autoloads in Emacs 28
-(autoload 'calc-grab-sum-down "calc" nil t)
-(autoload 'calc-grab-sum-across "calc" nil t)
-
 ;; this has had an autoload cookie since at least Emacs 26
 ;; but that autoload doesn't seem to work for me
 (autoload 'org-table-convert-region "org-table" nil t)
@@ -4403,7 +4386,7 @@ This simply calls RUN with the REST of its arguments inside
   :doc "Keymap for Embark heading actions."
   :parent embark-general-map
   "RET" 'outline-show-subtree
-  "TAB" 'outline-cycle ;; New in Emacs 28!
+  "TAB" 'outline-cycle
   "C-SPC" 'outline-mark-subtree
   "n" 'outline-next-visible-heading
   "p" 'outline-previous-visible-heading

--- a/embark.texi
+++ b/embark.texi
@@ -985,7 +985,7 @@ similar situations where the easiest option is not available.
 @node New minibuffer target example - tab-bar tabs
 @subsection New minibuffer target example - tab-bar tabs
 
-As an example, take the new @uref{https://www.gnu.org/software/emacs/manual/html_node/emacs/Tab-Bars.html, tab bars} from Emacs 27. I'll explain how
+As an example let us take a look at the @uref{https://www.gnu.org/software/emacs/manual/html_node/emacs/Tab-Bars.html, tab bars}. I'll explain how
 to configure Embark to offer tab-specific actions when you use the
 tab-bar-mode commands that mention tabs by name. The configuration
 explained here is now built-in to Embark (and Marginalia), but it's
@@ -1183,14 +1183,14 @@ bound by default in Embark's action keymaps are standard Emacs
 commands). It also allows you to write new custom actions in such a
 way that they are useful even without Embark.
 
-Staring from version 28.1, Emacs has a variable
-@samp{y-or-n-p-use-read-key}, which when set to @samp{t} causes @samp{y-or-n-p} to use
-@samp{read-key} instead of @samp{read-from-minibuffer}. Setting
-@samp{y-or-n-p-use-read-key} to @samp{t} is recommended for Embark users because
-it keeps Embark from attempting to insert the target at a @samp{y-or-n-p}
-prompt, which would almost never be sensible. Also consider this as
-a warning to structure your own action commands so that if they use
-@samp{y-or-n-p}, they do so only after the prompting for the target.
+Emacs has a variable @samp{y-or-n-p-use-read-key}, which when set to @samp{t}
+causes @samp{y-or-n-p} to use @samp{read-key} instead of @samp{read-from-minibuffer}.
+Setting @samp{y-or-n-p-use-read-key} to @samp{t} is recommended for Embark users
+because it keeps Embark from attempting to insert the target at a
+@samp{y-or-n-p} prompt, which would almost never be sensible. Also consider
+this as a warning to structure your own action commands so that if
+they use @samp{y-or-n-p}, they do so only after the prompting for the
+target.
 
 Here is a simple example illustrating the various ways of reading
 input from the user mentioned above. Bind the following commands to


### PR DESCRIPTION
With [Emacs 30](https://lists.gnu.org/archive/html/emacs-devel/2024-09/msg00305.html) on the final track I think we can safely drop support for Emacs 27.1 to reduce the amount of cruft we carry around. We still support the last three stable versions then. I've also made this move for [Marginalia](https://github.com/minad/marginalia/commit/16b7d03088656b597a253418e41a4a62c811993d) and [Consult](https://github.com/minad/consult/commit/eb71b39d282895b193a8002bddac5ca87891ac1e), so I think it won't hurt to also update the dependencies for Embark. I've not gotten any complaints. In any case, it should always be possible to use older versions on Emacs 27. For Embark, the code impact is not large, but in the case of Consult I could get rid of some larger workarounds for Emacs 27 bugs.