### PR TITLE
Fix error in face definition

### DIFF
--- a/embark.el
+++ b/embark.el
@@ -2656,7 +2656,7 @@ default is `embark-collect'"
   "Face for group titles in Embark Collect buffers.")
 
 (defface embark-collect-group-separator
-  '((t :inherit shadow :strike-through t italic))
+  '((t :inherit shadow :strike-through t :italic t))
   "Face for group titles in Embark Collect buffers.")
 
 (defcustom embark-collect-group-format


### PR DESCRIPTION
I don't actually know whether you actually meant to make this face italic, or the `italic` symbol should just be removed.