### PR TITLE
Simplify embark-target-completion-list-candidate for Emacs 28

### DIFF
--- a/avy-embark-collect.el
+++ b/avy-embark-collect.el
@@ -5,7 +5,7 @@
 ;; Author: Omar Antolín Camarena <omar@matem.unam.mx>
 ;; Keywords: convenience
 ;; Version: 0.3
-;; Homepage: https://github.com/oantolin/embark
+;; URL: https://github.com/oantolin/embark
 ;; Package-Requires: ((emacs "25.1") (embark "0.9") (avy "0.5"))
 
 ;; This program is free software; you can redistribute it and/or modify

--- a/embark-consult.el
+++ b/embark-consult.el
@@ -6,7 +6,7 @@
 ;; Maintainer: Omar Antolín Camarena <omar@matem.unam.mx>
 ;; Keywords: convenience
 ;; Version: 1.1
-;; Homepage: https://github.com/oantolin/embark
+;; URL: https://github.com/oantolin/embark
 ;; Package-Requires: ((emacs "28.1") (compat "30") (embark "1.1") (consult "1.8"))
 
 ;; This program is free software; you can redistribute it and/or modify

--- a/embark.el
+++ b/embark.el
@@ -1040,27 +1040,23 @@ their own target finder.  See for example
 (defun embark-target-completion-list-candidate ()
   "Return the completion candidate at point in a completions buffer."
   (when (derived-mode-p 'completion-list-mode)
-    (if (not (get-text-property (point) 'mouse-face))
-        (user-error "No completion here")
-      ;; this fairly delicate logic is taken from `choose-completion'
-      (let (beg end)
-        (cond
-         ((and (not (eobp)) (get-text-property (point) 'mouse-face))
-          (setq end (point) beg (1+ (point))))
-         ((and (not (bobp))
-               (get-text-property (1- (point)) 'mouse-face))
-          (setq end (1- (point)) beg (point)))
-         (t (user-error "No completion here")))
-        (setq beg (previous-single-property-change beg 'mouse-face))
-        (setq end (or (next-single-property-change end 'mouse-face)
-                      (point-max)))
-        (let ((raw (or (get-text-property beg 'completion--string)
-                       (buffer-substring beg end))))
-          `(,embark--type
-            ,(if (eq embark--type 'file)
-                 (abbreviate-file-name (expand-file-name raw))
-               raw)
-            ,beg . ,end))))))
+    ;; this fairly delicate logic is taken from `choose-completion'
+    (let (beg end)
+      (cond
+       ((and (not (eobp)) (get-text-property (point) 'completion--string))
+        (setq beg (1+ (point))))
+       ((and (not (bobp)) (get-text-property (1- (point)) 'completion--string))
+        (setq beg (point)))
+       (t (user-error "No completion here")))
+      (setq beg (or (previous-single-property-change beg 'completion--string) beg)
+            end (or (next-single-property-change beg 'completion--string)
+                    (point-max)))
+      (let ((raw (get-text-property beg 'completion--string)))
+        `(,embark--type
+          ,(if (eq embark--type 'file)
+               (abbreviate-file-name (expand-file-name raw))
+             raw)
+          ,beg . ,end)))))
 
 (defun embark--cycle-key ()
   "Return the key to use for `embark-cycle'."

--- a/embark.el
+++ b/embark.el
@@ -6,7 +6,7 @@
 ;; Maintainer: Omar Antolín Camarena <omar@matem.unam.mx>
 ;; Keywords: convenience
 ;; Version: 1.1
-;; Homepage: https://github.com/oantolin/embark
+;; URL: https://github.com/oantolin/embark
 ;; Package-Requires: ((emacs "28.1") (compat "30"))
 
 ;; This file is part of GNU Emacs.
@@ -121,7 +121,8 @@
 (defgroup embark nil
   "Emacs Mini-Buffer Actions Rooted in Keymaps."
   :link '(info-link :tag "Info Manual" "(embark)")
-  :link '(url-link :tag "Homepage" "https://github.com/oantolin/embark")
+  :link '(url-link :tag "Website" "https://github.com/oantolin/embark")
+  :link '(url-link :tag "Wiki" "https://github.com/oantolin/embark/wiki")
   :link '(emacs-library-link :tag "Library Source" "embark.el")
   :group 'minibuffer
   :prefix "embark-")


### PR DESCRIPTION
@oantolin We can simplify since we've raised the Embark dependency to Emacs 28, which always provides `completion--string`. Please test.