### PR TITLE
fix: limit set--this-command-keys to browse-url

### DIFF
--- a/embark.el
+++ b/embark.el
@@ -2070,12 +2070,15 @@ minibuffer before executing the action."
                             (embark--run-action-hooks embark-pre-action-hooks
                                                       action target quit)
                             (minibuffer-with-setup-hook inject
-                              ;; pacify commands that use (this-command-keys)
-                              (when (= (length (this-command-keys)) 0)
+                              ;; HACK work around `browse-url-interactive-arg'
+                              ;; expecting a non-empty `this-command-keys'
+                              ;; output.
+                              (when (and (eq action 'browse-url)
+                                         (= (length (this-command-keys)) 0))
                                 (set--this-command-keys
                                  (if (characterp last-command-event)
                                      (string last-command-event)
-                                  "\r")))
+                                   "\r")))
                               (setq this-command action)
                               (embark--run-around-action-hooks
                                action target quit)))


### PR DESCRIPTION
My view after investigating this #470 and #182 is that the underlying cause is a bug in `browse-url-interactive-arg` itself, as it should handle `this-command-keys` being the empty string or vector. However, even if that is fixed, older versions of Emacs will still have the issue. So I propose limiting the use of `set--this-command-keys` to the functions with `browse-url` in their name.