### PR TITLE
show keybinding instead of 'menu-item' in embark-bindings

### DIFF
--- a/embark.el
+++ b/embark.el
@@ -1309,7 +1309,7 @@ first line of the documentation string; for keyboard macros use
    (cond
     ((or (stringp cmd) (vectorp cmd)) (key-description cmd))
     ((stringp (car-safe cmd)) (car cmd))
-    ((eq (car-safe cmd) 'menu-item) (eval (cadr cmd)))
+    ((eq (car-safe cmd) 'menu-item) (format "%S" (caddr cmd)))
     ((keymapp cmd)
      (propertize (if (symbolp cmd) (format "+%s" cmd) "<keymap>")
                  'face 'embark-keymap))
@@ -1372,10 +1372,7 @@ If NESTED is non-nil subkeymaps are not flattened."
                    unless (memq cmd '(nil embark-keymap-help
                                       negative-argument digit-argument))
                    collect (list name cmd key
-                                 (concat
-                                  (if (eq (car-safe def) 'menu-item)
-                                      "menu-item"
-                                    (key-description key))))))
+                                 (concat (key-description key)))))
          (width (cl-loop for (_name _cmd _key desc) in commands
                          maximize (length desc)))
          (default)


### PR DESCRIPTION
A "works-for-me" pull request which aims to fix #715, and seems to be in line with what is hinted at in #724.

Seems to work in my limited testing, no harm if others test it as well.