### PR TITLE
Treat computed space better in embark--display-string

### DIFF
--- a/embark.el
+++ b/embark.el
@@ -3094,8 +3094,10 @@ For non-minibuffers, assume candidates are of given TYPE."
     (while (< pos end)
       (let ((nextd (next-single-property-change pos 'display str end))
             (disp (get-text-property pos 'display str)))
-        (if (stringp disp)
+        (if (or (stringp disp) (eq (car-safe disp) 'space))
             (let ((face (get-text-property pos 'face str)))
+              (unless (stringp disp)
+                (setq disp " "))
               (when face
                 (add-face-text-property
                  0 (length disp) face t (setq disp (concat disp))))


### PR DESCRIPTION
See also https://github.com/minad/vertico/commit/9132ab8a7e294a04d411cbcd67902052210eb14d.

It would be good to keep these in sync.