### PR TITLE
Treat computed space better in embark--display-string

### DIFF
--- a/embark.el
+++ b/embark.el
@@ -3100,6 +3100,7 @@ For non-minibuffers, assume candidates are of given TYPE."
                 (add-face-text-property
                  0 (length disp) face t (setq disp (concat disp))))
               (setq pos nextd chunks (cons disp chunks)))
+          (pcase disp (`(space :align-to . ,_) (push " " chunks)))
           (while (< pos nextd)
             (let ((nexti
                    (next-single-property-change pos 'invisible str nextd)))


### PR DESCRIPTION
See also https://github.com/minad/vertico/commit/14cc82fc56b34482b33fb0175ec3044ab9a50003

It would be good to keep these in sync.

@oantolin I found this when working with computed space in Elfeed buffers. The problem is that align-to is relative to the left border by default, and since the candidates obtained by consult-line are reformatted with line numbers in front, the align-to space might collapse to a zero width space. Vertico and the Embark snapshot buffer are affected by this. Therefore always add a single space to make sure that the candidates do not look compressed. Compute space with :width does not have that problem. See https://github.com/emacs-elfeed/elfeed/commit/b92434b0b18b94402cb6dc1cbbcf92704f2e402e for reference.

I believe I had such zero space compression in other buffers with alignment before, when invoking consult-line. But I don't remember which mode was affected. So it seems good to do this, even if it is a bit of a hack.
