### PR TITLE
Rename CHANGELOG.org to NEWS.org

### DIFF
--- a/NEWS.org
+++ b/NEWS.org
@@ -1,4 +1,6 @@
-#+title: Embark changelog
+#+title: Embark News
+#+author: Omar Antolín Camarena
+#+language: en
 
 * Development version
 - The target finders for outline headings now also work with heading


### PR DESCRIPTION
This way the ELPA builder will pick up the news and show them on the website https://elpa.gnu.org/devel/embark.html.